### PR TITLE
implement error handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -1127,6 +1127,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1422,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -1469,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schannel"
@@ -1549,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -1606,9 +1607,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -1654,18 +1655,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1861,9 +1862,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 rand = "0.8.5"
 serde = "1.0.152"
 serde_json="1.0"
+thiserror = "1.0.39"
 
 [[bin]]
 name = "vault"

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,0 +1,47 @@
+use std::string::FromUtf8Error;
+
+use aws_sdk_cloudformation::types::SdkError;
+use thiserror::Error;
+#[derive(Debug, Error)]
+pub enum VaultError {
+    #[error("Describe CloudFormation Stack failed")]
+    DescribeStackError(#[from] SdkError<aws_sdk_cloudformation::error::DescribeStacksError>),
+    #[error("CloudFormation Stack outputs missing")]
+    StackOutputsMissingError,
+    #[error("Error getting bucket name from stack")]
+    BucketNameMissingError,
+    #[error("No KEY_ARN provided, can't encrypt")]
+    KeyARNMissingError,
+    #[error("Error Generating KMS Data key")]
+    KMSGenerateDataKeyError(#[from] SdkError<aws_sdk_kms::error::GenerateDataKeyError>),
+    #[error("Error decrypting Ciphertext with KMS")]
+    KMSDecryptError(#[from] SdkError<aws_sdk_kms::error::DecryptError>),
+    #[error("No Plaintext for generated datakey")]
+    KMSDataKeyPlainTextMissingError,
+    #[error("No ciphertextBlob for generated datakey")]
+    KMSDataKeyCiphertextBlobMissingError,
+    #[error("Invalid length for encryption cipher")]
+    InvalidNonceLengthError(#[from] aes_gcm::aes::cipher::InvalidLength),
+    #[error("Invalid length for encryption cipher")]
+    NonceDecryptError,
+    #[error("Error, string not valid UTF8")]
+    NonUtf8BodyError(#[from] FromUtf8Error),
+    #[error("Error encrypting ciphertext")]
+    CiphertextEncryptionError,
+    #[error("Error parsing meta with serde")]
+    EncryptObjectMetaToJsonError(#[from] serde_json::Error),
+    #[error("failed getting object from S3")]
+    S3GetObjectError(#[from] SdkError<aws_sdk_s3::error::GetObjectError>),
+    #[error("error decrypting S3-object body")]
+    S3GetObjectBodyError,
+    #[error("error putting object to S3")]
+    S3PutObjectError(#[from] SdkError<aws_sdk_s3::error::PutObjectError>),
+    #[error("error listing S3 objects")]
+    S3ListObjectsError(#[from] SdkError<aws_sdk_s3::error::ListObjectsV2Error>),
+    #[error("No contents found from S3")]
+    S3NoContentsError,
+    #[error("error getting region")]
+    NoRegionError,
+    #[error("error parsing Nonce from base64")]
+    NonceParseError(#[from] base64::DecodeError),
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,15 +3,16 @@ use aes_gcm::{
     aes::{cipher::typenum, Aes256},
     AesGcm, KeyInit, Nonce,
 };
-
 use aws_config::{meta::region::RegionProviderChain, SdkConfig};
 use aws_sdk_cloudformation::{model::Output, Client as cfClient};
 use aws_sdk_kms::{model::DataKeySpec, types::Blob, Client as kmsClient};
 use aws_sdk_s3::{types::ByteStream, Client as s3Client, Region};
 use base64::{engine::general_purpose, Engine as _};
+use errors::VaultError;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
+pub mod errors;
 #[derive(Debug)]
 pub struct Vault {
     region: Region,
@@ -49,7 +50,10 @@ fn get_region_provider(region_opt: Option<&str>) -> RegionProviderChain {
 }
 
 impl Vault {
-    pub async fn new(vault_stack: Option<&str>, region_opt: Option<&str>) -> Result<Vault, String> {
+    pub async fn new(
+        vault_stack: Option<&str>,
+        region_opt: Option<&str>,
+    ) -> Result<Vault, VaultError> {
         let config = aws_config::from_env()
             .region(get_region_provider(region_opt))
             .load()
@@ -66,13 +70,13 @@ impl Vault {
     pub async fn from_params(
         cf_params: CfParams,
         region_opt: Option<&str>,
-    ) -> Result<Vault, String> {
+    ) -> Result<Vault, VaultError> {
         let config = aws_config::from_env()
             .region(get_region_provider(region_opt))
             .load()
             .await;
         Ok(Vault {
-            region: config.region().ok_or("error getting region")?.to_owned(),
+            region: config.region().ok_or(VaultError::NoRegionError)?.to_owned(),
             cf_params,
             s3: s3Client::new(&config),
             kms: kmsClient::new(&config),
@@ -86,38 +90,40 @@ impl Vault {
         );
     }
 
-    pub async fn all(&self) -> Result<Vec<String>, String> {
+    pub async fn all(&self) -> Result<Vec<String>, VaultError> {
         let output = self
             .s3
             .list_objects_v2()
             .bucket(&self.cf_params.bucket_name)
             .send()
-            .await
-            .map_err(|e| format!("{e:#?}"))?;
-        Ok(output
+            .await?;
+        output
             .contents()
-            .ok_or("error getting S3 output contents")?
-            .iter()
-            .filter_map(|object| -> Option<String> {
-                if let Some(key) = object.key() {
-                    if key.ends_with(".aesgcm.encrypted") {
-                        key.strip_suffix(".aesgcm.encrypted")
-                            .map(|stripped| stripped.to_owned())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+            .map(|objects| {
+                objects
+                    .iter()
+                    .filter_map(|object| -> Option<String> {
+                        if let Some(key) = object.key() {
+                            if key.ends_with(".aesgcm.encrypted") {
+                                key.strip_suffix(".aesgcm.encrypted")
+                                    .map(|stripped| stripped.to_owned())
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
             })
-            .collect())
+            .ok_or(VaultError::S3NoContentsError)
     }
 
     pub fn stack_info(&self) -> CfParams {
         self.cf_params.to_owned()
     }
 
-    async fn encrypt(&self, data: &[u8]) -> Result<EncryptObject, String> {
+    async fn encrypt(&self, data: &[u8]) -> Result<EncryptObject, VaultError> {
         let key_dict = self
             .kms
             .generate_data_key()
@@ -125,18 +131,17 @@ impl Vault {
                 self.cf_params
                     .key_arn
                     .to_owned()
-                    .ok_or("No KEY_ARN provided, can't encrypt")?,
+                    .ok_or(VaultError::KeyARNMissingError)?,
             )
             .key_spec(DataKeySpec::Aes256)
             .send()
-            .await
-            .map_err(|e| format!("{e:#?}"))?;
+            .await?;
 
         let plaintext = key_dict
             .plaintext()
-            .ok_or("No Plaintext for generated datakey")?;
+            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)?;
         let aesgcm_cipher: AesGcm<Aes256, typenum::U12> =
-            AesGcm::new_from_slice(plaintext.as_ref()).map_err(|e| format!("{e:#?}"))?;
+            AesGcm::new_from_slice(plaintext.as_ref())?;
         let mut nonce: [u8; 12] = [0; 12];
         let mut rng = rand::thread_rng();
         rng.fill(nonce.as_mut_slice());
@@ -145,8 +150,7 @@ impl Vault {
         let meta = serde_json::to_string(&Meta {
             alg: "AESGCM".to_owned(),
             nonce: general_purpose::STANDARD.encode(nonce),
-        })
-        .map_err(|e| format!("{e:#?}"))?;
+        })?;
 
         let aes_gcm_ciphertext = aesgcm_cipher
             .encrypt(
@@ -156,12 +160,11 @@ impl Vault {
                     aad: meta.as_bytes(),
                 },
             )
-            .map_err(|e| format!("{e:#?}"))?;
-
+            .map_err(|_| VaultError::CiphertextEncryptionError)?;
         Ok(EncryptObject {
             data_key: key_dict
                 .ciphertext_blob()
-                .ok_or("No ciphertextBlob on Datakey")?
+                .ok_or(VaultError::CiphertextEncryptionError)?
                 .to_owned()
                 .into_inner(),
             aes_gcm_ciphertext,
@@ -169,89 +172,79 @@ impl Vault {
         })
     }
 
-    async fn get_s3_obj_as_vec(&self, key: String) -> Result<Vec<u8>, String> {
+    async fn get_s3_obj_as_vec(&self, key: String) -> Result<Vec<u8>, VaultError> {
         self.s3
             .get_object()
             .bucket(self.cf_params.bucket_name.to_owned())
             .key(&key)
             .send()
-            .await
-            .map_err(|e| format!("{e:#?}"))?
+            .await?
             .body
             .collect()
             .await
-            .map(|body| body.to_vec())
-            .map_err(|e| format!("{e:#?}"))
+            .map_err(|_| VaultError::S3GetObjectBodyError)
+            .map(|bytes| bytes.to_vec())
     }
 
-    async fn direct_decrypt(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, String> {
+    async fn direct_decrypt(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, VaultError> {
         self.kms
             .decrypt()
             .ciphertext_blob(Blob::new(encrypted_data))
             .send()
-            .await
-            .map_err(|e| format!("{e:#?}"))?
+            .await?
             .plaintext()
             .map(|blob| blob.to_owned().into_inner())
-            .ok_or("Error parsing KMS plaintext".to_owned())
+            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)
     }
 
     async fn put_s3_obj(
         &self,
         body: aws_sdk_s3::types::ByteStream,
         key: &str,
-    ) -> Result<
-        aws_sdk_s3::output::PutObjectOutput,
-        aws_sdk_cloudformation::types::SdkError<aws_sdk_s3::error::PutObjectError>,
-    > {
-        self.s3
+    ) -> Result<aws_sdk_s3::output::PutObjectOutput, VaultError> {
+        Ok(self
+            .s3
             .put_object()
             .bucket(&self.cf_params.bucket_name)
             .key(key)
             .acl(aws_sdk_s3::model::ObjectCannedAcl::Private)
             .body(body)
             .send()
-            .await
+            .await?)
     }
 
-    pub async fn store(&self, name: &str, data: &[u8]) -> Result<(), String> {
-        let encrypted = self.encrypt(data).await.map_err(|e| format!("{e:#?}"))?;
+    pub async fn store(&self, name: &str, data: &[u8]) -> Result<(), VaultError> {
+        let encrypted = self.encrypt(data).await?;
         self.put_s3_obj(
             ByteStream::from(encrypted.aes_gcm_ciphertext),
             &format!("{}.aesgcm.encrypted", name),
         )
-        .await
-        .map_err(|e| format!("{e:#?}"))?;
+        .await?;
 
         self.put_s3_obj(
             ByteStream::from(encrypted.data_key),
             &format!("{}.key", name),
         )
-        .await
-        .map_err(|e| format!("{e:#?}"))?;
+        .await?;
 
         self.put_s3_obj(
             ByteStream::from(encrypted.meta.as_bytes().to_owned()),
             &format!("{}.meta", name),
         )
-        .await
-        .map_err(|e| format!("{e:#?}"))?;
+        .await?;
 
         Ok(())
     }
 
-    pub async fn lookup(&self, name: &str) -> Result<String, String> {
+    pub async fn lookup(&self, name: &str) -> Result<String, VaultError> {
         let key = name;
         let data_key = self.get_s3_obj_as_vec(format!("{key}.key"));
         let ciphertext = self.get_s3_obj_as_vec(format!("{key}.aesgcm.encrypted"));
         let meta_add = self.get_s3_obj_as_vec(format!("{key}.meta")).await?;
-        let meta: Meta = serde_json::from_slice(&meta_add).map_err(|e| format!("{e:#?}"))?;
+        let meta: Meta = serde_json::from_slice(&meta_add)?;
         let cipher: AesGcm<Aes256, typenum::U12> =
-            AesGcm::new_from_slice(self.direct_decrypt(&data_key.await?).await?.as_slice())
-                .map_err(|e| format!("{e:#?}"))?;
-        let nonce = general_purpose::STANDARD
-            .decode(meta.nonce)
-            .map_err(|e| format!("{e:#?}"))?;
+            AesGcm::new_from_slice(self.direct_decrypt(&data_key.await?).await?.as_slice())?;
+        let nonce = general_purpose::STANDARD.decode(meta.nonce)?;
         let nonce = Nonce::from_slice(nonce.as_slice());
         let res = cipher
             .decrypt(
@@ -261,8 +254,8 @@ impl Vault {
                     aad: &meta_add,
                 },
             )
-            .map_err(|e| format!("{e:#?}"))?;
-        String::from_utf8(res).map_err(|e| format!("{e:#?}"))
+            .map_err(|_| VaultError::NonceDecryptError)?;
+        Ok(String::from_utf8(res)?)
     }
 }
 
@@ -278,22 +271,21 @@ fn parse_output_value_from_key(key: &str, out: &[Output]) -> Option<String> {
         .map(|output| output.output_value().unwrap_or_default().to_owned())
 }
 
-async fn get_cf_params(config: &SdkConfig, stack: &str) -> Result<CfParams, String> {
+async fn get_cf_params(config: &SdkConfig, stack: &str) -> Result<CfParams, VaultError> {
     let stack_output = cfClient::new(config)
         .describe_stacks()
         .stack_name(stack)
         .send()
-        .await
-        .map_err(|e| format!("{e:#?}"))?
+        .await?
         .stacks()
         .and_then(|stacks| stacks.first())
         .and_then(|stack| stack.outputs())
-        .ok_or("Error getting Cloudformation Stack Ouput")?
+        .ok_or(VaultError::StackOutputsMissingError)?
         .to_owned();
 
     Ok(CfParams {
         bucket_name: parse_output_value_from_key("vaultBucketName", &stack_output)
-            .ok_or("Error getting bucket name from stack")?,
+            .ok_or(VaultError::BucketNameMissingError)?,
         key_arn: parse_output_value_from_key("kmsKeyArn", &stack_output),
         // deployed_version: parse_output_value_from_key("vaultStackVersion", &stack_output),
     })

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -68,13 +68,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args: Args = parse_args().await;
 
     // how to implement this better
-    let client = match Vault::new(None, args.region.as_deref()).await {
-        Ok(vault) => vault,
-        Err(error) => return Ok(println!("Error creating vault:\n{error}")),
-    };
-
+    let client = Vault::new(None, args.region.as_deref()).await?;
     if args.all {
-        list_all(&client).await;
+        list_all(&client).await?;
         return Ok(());
     } else if args.describestack {
         println!("{:#?}", client.stack_info());
@@ -84,22 +80,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    if let Some(key) = args.lookup.as_deref() {
-        print!("{}", client.lookup(key).await.unwrap());
+    if let Some(name) = args.lookup.as_deref() {
+        print!("{}", client.lookup(name).await?);
         return Ok(());
     }
 
     match &args.command {
         Some(Commands::List {}) => {
-            list_all(&client).await;
+            list_all(&client).await?;
             Ok(())
         }
         Some(Commands::Load { key }) => {
-            print!("{}", client.lookup(key).await.unwrap());
+            print!("{}", client.lookup(key).await?);
             Ok(())
         }
         Some(Commands::Store { key, value }) => {
-            client.store(key, value).await.unwrap();
+            client.store(key, value).await?;
             Ok(())
         }
         None => Ok(()),
@@ -110,9 +106,6 @@ async fn parse_args() -> Args {
     Args::parse()
 }
 
-async fn list_all(vault: &Vault) {
-    match vault.all().await {
-        Ok(all) => println!("{}", all.join("\n")),
-        Err(error) => println!("error occurred: {}", error),
-    }
+async fn list_all(vault: &Vault) -> Result<(), nitor_vault::errors::VaultError> {
+    Ok(println!("{}", vault.all().await?.join("\n")))
 }


### PR DESCRIPTION
Using `thiserror` and deriving most of the errors from libraries gives a nicer ergonomy for error handling.

example when trying lookup with missing credentials:
```shell
~/src/github/vault/rust (rust-lib-error-handling) » cargo run load testingtesting
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/vault load testingtesting`
Error: DescribeStackError(ConstructionFailure(ConstructionFailure { source: SigningStageError { kind: MissingCredentials } }))