### PR TITLE
Separate cli module for rust

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Black
         uses: psf/black@stable
         with:
-          options: "--check --verbose --diff --color"
+          options: "--check --verbose --diff --color --config python/pyproject.toml"
+          src: "python/"

--- a/python/n_vault/cli.py
+++ b/python/n_vault/cli.py
@@ -39,8 +39,16 @@ def main():
         nargs="?",
         default="",
     )
-    action.add_argument("-l", "--lookup", help="Name of element to lookup")
-    action.add_argument("-c", "--recrypt", help="Recrypt entry with AESGCM for added security")
+    action.add_argument(
+        "-l",
+        "--lookup",
+        help="Name of element to lookup",
+    )
+    action.add_argument(
+        "-c",
+        "--recrypt",
+        help="Recrypt entry with AESGCM for added security",
+    )
     action.add_argument(
         "-i",
         "--init",
@@ -55,10 +63,27 @@ def main():
         action="store_true",
         help="Updates the CloudFormation stack which declares all resources needed by the vault.",
     )
-    action.add_argument("-d", "--delete", help="Name of element to delete")
-    action.add_argument("-a", "--all", action="store_true", help="List available secrets")
-    action.add_argument("-e", "--encrypt", help="Directly encrypt given value")
-    action.add_argument("-y", "--decrypt", help="Directly decrypt given value")
+    action.add_argument(
+        "-d",
+        "--delete",
+        help="Name of element to delete",
+    )
+    action.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help="List available secrets",
+    )
+    action.add_argument(
+        "-e",
+        "--encrypt",
+        help="Directly encrypt given value",
+    )
+    action.add_argument(
+        "-y",
+        "--decrypt",
+        help="Directly decrypt given value",
+    )
     parser.add_argument(
         "-w",
         "--overwrite",

--- a/python/release.sh
+++ b/python/release.sh
@@ -67,16 +67,16 @@ git push origin "$NEW_VERSION"
 rm -rf dist
 
 if [ -n "$(command -v python3)" ]; then
-    PYTHON=$(which python3)
+  PYTHON=$(which python3)
 else
-    PYTHON=$(which python)
+  PYTHON=$(which python)
 fi
 
 if [ ! -e "$PYTHON" ]; then
-    echo "Python executable not found: $PYTHON"
-    exit 1
+  echo "Python executable not found: $PYTHON"
+  exit 1
 else
-    echo "Using $PYTHON $($PYTHON --version)"
+  echo "Using $PYTHON $($PYTHON --version)"
 fi
 
 $PYTHON setup.py sdist bdist_wheel

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -564,9 +564,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -764,24 +764,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -790,21 +790,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -942,9 +942,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1062,9 +1062,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1323,18 +1323,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1531,24 +1531,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1863,9 +1863,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
@@ -2074,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2089,45 +2089,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "xmlparser"

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,6 +13,28 @@ cargo build --release
 cargo run --release
 ```
 
+Cargo will output the executable to either
+
+```shell
+rust/target/debug/vault
+rust/target/release/vault
+```
+
+depending on which build profile is used.
+
+## Install
+
+You can install a release binary locally using [cargo install](https://doc.rust-lang.org/cargo/commands/cargo-install.html).
+Note that you need to specify the path to the directory containing [Cargo.toml](./Cargo.toml),
+so from the repo root you would do:
+
+```shell
+cargo install --path rust/
+```
+
+Cargo will put the binary under `$HOME/.cargo/bin` by default, which you should add to PATH if you don't have it there,
+so the binaries installed through Cargo will be found.
+
 ## Format code
 
 Using [rustfmt](https://github.com/rust-lang/rustfmt)

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # nitor-vault
 
-CLI and library for encrypting keys and values using client-side encryption with AWS KMS keys.
+CLI and library for encrypting keys and values using client-side encryption with [AWS KMS](https://aws.amazon.com/kms/) keys.
 
 ## Build
 
@@ -32,7 +32,8 @@ so from the repo root you would do:
 cargo install --path rust/
 ```
 
-Cargo will put the binary under `$HOME/.cargo/bin` by default, which you should add to PATH if you don't have it there,
+Cargo will put the binary under `$HOME/.cargo/bin` by default,
+which you should add to PATH if you don't have it there,
 so the binaries installed through Cargo will be found.
 
 ## Format code
@@ -43,7 +44,7 @@ Using [rustfmt](https://github.com/rust-lang/rustfmt)
 cargo fmt
 ```
 
-## Lint
+## Lint code
 
 Using [Clippy](https://github.com/rust-lang/rust-clippy)
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -25,7 +25,7 @@ depending on which build profile is used.
 ## Install
 
 You can install a release binary locally using [cargo install](https://doc.rust-lang.org/cargo/commands/cargo-install.html).
-Note that you need to specify the path to the directory containing [Cargo.toml](./Cargo.toml),
+Note that you need to specify the path to the directory containing [Cargo.toml](/Cargo.toml),
 so from the repo root you would do:
 
 ```shell

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -152,7 +152,7 @@ pub async fn store(
     vault
         .store(key, data.as_bytes())
         .await
-        .with_context(|| format!("Error saving key {key}"))
+        .with_context(|| format!("Error saving key '{key}'"))
 }
 
 pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
@@ -162,7 +162,7 @@ pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
     vault
         .delete(key)
         .await
-        .with_context(|| format!("Error deleting key '{key}'."))
+        .with_context(|| format!("Error deleting key '{key}'"))
 }
 
 pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -142,7 +142,7 @@ pub async fn store(
         && vault
             .exists(key)
             .await
-            .with_context(|| format!("Error checking if key {key} exists"))?
+            .with_context(|| format!("Error checking if key '{key}' exists"))?
     {
         anyhow::bail!(
             "Error saving key, it already exists and you did not provide \x1b[33m-w\x1b[0m flag for overwriting"
@@ -152,27 +152,27 @@ pub async fn store(
     vault
         .store(key, data.as_bytes())
         .await
-        .with_context(|| format!("Error saving key {}", key))
+        .with_context(|| format!("Error saving key {key}"))
 }
 
 pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
+        anyhow::bail!("Empty key '{key}'")
     }
     vault
         .delete(key)
         .await
-        .with_context(|| format!("Error deleting key '{}'.", key))
+        .with_context(|| format!("Error deleting key '{key}'."))
 }
 
 pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
+        anyhow::bail!("Empty key '{key}'")
     }
     vault
         .lookup(key)
         .await
-        .with_context(|| format!("Error looking up key '{}'.", key))
+        .with_context(|| format!("Error looking up key '{key}'"))
         .map(|res| print!("{res}"))
 }
 
@@ -186,12 +186,12 @@ pub async fn list_all(vault: &Vault) -> Result<()> {
 
 pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
+        anyhow::bail!("Empty key '{key}'")
     }
     vault
         .exists(key)
         .await
-        .with_context(|| format!("Error checking if key {key} exists"))
+        .with_context(|| format!("Error checking if key '{key}' exists"))
         .map(|result| match result {
             true => println!("key {key} exists"),
             false => println!("key {key} doesn't exist"),

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -10,7 +10,6 @@ use nitor_vault::Vault;
     version,
     about,
     long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples",
-    subcommand_required = true,
     arg_required_else_help = true
 )] // Reads info from `Cargo.toml`
 pub struct Args {
@@ -23,7 +22,7 @@ pub struct Args {
         long,
         help = "Describe CloudFormation stack parameters for current configuration"
     )]
-    pub describestack: bool,
+    pub describe: bool,
 
     /// Delete key
     #[arg(short, long, help = "Delete key", value_name = "KEY")]
@@ -58,7 +57,7 @@ pub enum Command {
 
     /// Describe CloudFormation stack parameters for current configuration.
     // This value is useful for Lambdas as you can load the CloudFormation parameters from env.
-    DescribeStack {},
+    Describe {},
 
     /// Check if a key exists
     Exists { key: String },

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -86,10 +86,15 @@ pub enum Command {
     },
 }
 
+/// Parse command line arguments.
+///
+/// See Clap `Derive` documentation for details:
+/// https://docs.rs/clap/latest/clap/_derive/index.html
 pub async fn parse_args() -> Args {
     Args::parse()
 }
 
+/// Store key-value pair
 pub async fn store(
     vault: &Vault,
     key: &Option<String>,

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Args {
 
     /// Delete key
     #[arg(short, long, help = "Delete key", value_name = "KEY")]
-    pub delete: String,
+    pub delete: Option<String>,
 
     /// Print debug information
     #[arg(long, help = "Print information")]

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -75,7 +75,7 @@ pub enum Command {
     /// Check if a key exists
     Exists { key: String },
     /// Describe CloudFormation stack params for current configuration.
-    /// This value is useful for Lambdas as you can load the CfParams from env rather than from CloudFormation.
+    /// This value is useful for Lambdas as you can load the CloudFormation parameters from env.
     DescribeStack {},
 }
 

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -1,0 +1,188 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use std::io::{stdin, BufRead};
+
+use nitor_vault::Vault;
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples"
+)] // Reads info from `Cargo.toml`
+pub struct Args {
+    /// List all available secrets
+    #[arg(short, long, help = "List available secrets")]
+    pub all: bool,
+
+    /// Describe CloudFormation stack parameters
+    #[arg(
+        long,
+        help = "Describe CloudFormation stack parameters for current configuration"
+    )]
+    pub describestack: bool,
+
+    /// Delete key
+    #[arg(short, long, help = "Delete key", value_name = "KEY")]
+    pub delete: String,
+
+    /// Print debug information
+    #[arg(long, help = "Print information")]
+    pub info: bool,
+
+    /// Print secret value for given key
+    #[arg(
+        short,
+        long,
+        help = "Print secret value for given key",
+        value_name = "KEY"
+    )]
+    pub lookup: Option<String>,
+
+    /// Specify AWS region to use
+    #[arg(short, long, help = "Specify AWS region for the bucket")]
+    pub region: Option<String>,
+
+    /// Available subcommands
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// List available secrets
+    List {},
+    /// Print secret value for given key
+    Load { key: String },
+    /// Store new key-value pair
+    Store {
+        key: Option<String>,
+        #[arg(short = 'w', long, help = "Overwrite existing key")]
+        overwrite: bool,
+        value: Option<String>,
+        #[arg(
+            short,
+            long,
+            help = "Point to a file that will be stored, - for stdin",
+            value_name = "filename",
+            conflicts_with = "value"
+        )]
+        file: Option<String>,
+    },
+    /// Delete an existing key from the store
+    Delete { key: String },
+    /// Check if a key exists
+    Exists { key: String },
+    /// Describe CloudFormation stack params for current configuration.
+    /// This value is useful for Lambdas as you can load the CfParams from env rather than from CloudFormation.
+    DescribeStack {},
+}
+
+pub async fn parse_args() -> Args {
+    Args::parse()
+}
+
+pub async fn store(
+    vault: &Vault,
+    key: &Option<String>,
+    value: &Option<String>,
+    file: &Option<String>,
+    overwrite: &bool,
+) -> Result<()> {
+    let key = {
+        if let Some(key) = key {
+            key
+        } else if let Some(file_name) = file {
+            match file_name.as_str() {
+                "-" => anyhow::bail!("Key cannot be empty when reading from stdin"),
+                _ => file_name,
+            }
+        } else {
+            anyhow::bail!(
+                "Empty key and no \x1b[33m-f\x1b[0m flag provided, provide at least one of these"
+            )
+        }
+    };
+
+    let data = {
+        if let Some(value) = value {
+            value.to_owned()
+        } else if let Some(path) = file {
+            match path.as_str() {
+                "-" => {
+                    println!("Reading from stdin, empty line stops reading");
+                    stdin()
+                        .lock()
+                        .lines()
+                        .map(|l| l.unwrap())
+                        .take_while(|l| !l.trim().is_empty())
+                        .fold(String::new(), |acc, line| acc + &line + "\n")
+                }
+                _ => std::fs::read_to_string(path)
+                    .with_context(|| format!("Error reading file '{path}'"))?,
+            }
+        } else {
+            anyhow::bail!("No value or filename provided")
+        }
+    };
+
+    if !overwrite
+        && vault
+            .exists(key)
+            .await
+            .with_context(|| format!("Error checking if key {key} exists"))?
+    {
+        anyhow::bail!(
+            "Error saving key, it already exists and you did not provide \x1b[33m-w\x1b[0m flag for overwriting"
+        )
+    }
+
+    vault
+        .store(key, data.as_bytes())
+        .await
+        .with_context(|| format!("Error saving key {}", key))
+}
+
+pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
+    if key.trim().is_empty() {
+        anyhow::bail!("Empty key '{}'", key)
+    }
+    vault
+        .delete(key)
+        .await
+        .with_context(|| format!("Error deleting key '{}'.", key))
+}
+
+pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
+    if key.trim().is_empty() {
+        anyhow::bail!("Empty key '{}'", key)
+    }
+    vault
+        .lookup(key)
+        .await
+        .with_context(|| format!("Error looking up key '{}'.", key))
+        .map(|res| print!("{res}"))
+}
+
+pub async fn list_all(vault: &Vault) -> Result<()> {
+    vault
+        .all()
+        .await
+        .with_context(|| "Error listing all keys".to_string())
+        .map(|list| println!("{}", list.join("\n")))
+}
+
+pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
+    if key.trim().is_empty() {
+        anyhow::bail!("Empty key '{}'", key)
+    }
+    vault
+        .exists(key)
+        .await
+        .with_context(|| format!("Error checking if key {key} exists"))
+        .map(|result| match result {
+            true => println!("key {key} exists"),
+            false => println!("key {key} doesn't exist"),
+        })
+}

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -9,7 +9,9 @@ use nitor_vault::Vault;
     author,
     version,
     about,
-    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples"
+    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples",
+    subcommand_required = true,
+    arg_required_else_help = true
 )] // Reads info from `Cargo.toml`
 pub struct Args {
     /// List all available secrets
@@ -54,8 +56,8 @@ pub enum Command {
     /// Delete an existing key from the store
     Delete { key: String },
 
-    /// Describe CloudFormation stack params for current configuration.
-    /// This value is useful for Lambdas as you can load the CloudFormation parameters from env.
+    /// Describe CloudFormation stack parameters for current configuration.
+    // This value is useful for Lambdas as you can load the CloudFormation parameters from env.
     DescribeStack {},
 
     /// Check if a key exists

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -51,10 +51,22 @@ pub struct Args {
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// Delete an existing key from the store
+    Delete { key: String },
+
+    /// Describe CloudFormation stack params for current configuration.
+    /// This value is useful for Lambdas as you can load the CloudFormation parameters from env.
+    DescribeStack {},
+
+    /// Check if a key exists
+    Exists { key: String },
+
     /// List available secrets
     List {},
+
     /// Print secret value for given key
     Load { key: String },
+
     /// Store new key-value pair
     Store {
         key: Option<String>,
@@ -70,13 +82,6 @@ pub enum Command {
         )]
         file: Option<String>,
     },
-    /// Delete an existing key from the store
-    Delete { key: String },
-    /// Check if a key exists
-    Exists { key: String },
-    /// Describe CloudFormation stack params for current configuration.
-    /// This value is useful for Lambdas as you can load the CloudFormation parameters from env.
-    DescribeStack {},
 }
 
 pub async fn parse_args() -> Args {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,6 +11,7 @@ use base64::{engine::general_purpose, Engine as _};
 use errors::VaultError;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub mod errors;
 
@@ -49,6 +50,20 @@ impl CloudFormationParams {
             bucket_name: bucket_name.to_owned(),
             key_arn: key_arn.map(|x| x.to_owned()),
         }
+    }
+}
+
+impl fmt::Display for CloudFormationParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "bucket: {}\nkey: {}",
+            self.bucket_name,
+            match &self.key_arn {
+                None => "None".to_string(),
+                Some(k) => k.to_string(),
+            }
+        )
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,8 +13,10 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 pub mod errors;
+
 #[derive(Debug)]
 pub struct Vault {
+    /// AWS region to use with Vault. Will fallback to default provider if nothing is specified.
     region: Region,
     cf_params: CfParams,
     s3: s3Client,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,98 +1,21 @@
-use std::io::{stdin, BufRead};
-
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+
 use nitor_vault::Vault;
 
-#[derive(Parser)]
-#[command(
-    author,
-    version,
-    about,
-    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples"
-)] // Reads info from `Cargo.toml`
-struct Args {
-    #[arg(short, long, help = "List available secrets")]
-    all: bool,
+use cli::{Args, Command};
 
-    #[arg(
-        long,
-        help = "Describe CloudFormation stack params for current configuration"
-    )]
-    describestack: bool,
-
-    // TODO
-    //#[arg(short, long, help = "Delete key", value_name = "KEY")]
-    //delete: Option<String>,
-    #[arg(long, help = "Print information")]
-    info: bool,
-
-    #[arg(
-        short,
-        long,
-        help = "Print secret value for given key",
-        value_name = "KEY"
-    )]
-    lookup: Option<String>,
-
-    // TODO
-    //#[arg(short = 'w', long, help = "Overwrite existing key", value_name = "KEY")]
-    //overwrite: Option<String>,
-    #[arg(short, long, help = "Specify region for the bucket")]
-    region: Option<String>,
-
-    // TODO
-    //#[arg(
-    //    short,
-    //    long,
-    //    help = "Updates the CloudFormation stack that declares all resources needed by the vault",
-    //    value_name = "KEY"
-    //)]
-    //update: Option<String>,
-    #[command(subcommand)]
-    command: Option<Commands>,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// List available secrets
-    List {},
-    /// Print secret value for given key
-    Load { key: String },
-    /// Store new key-value pair
-    Store {
-        key: Option<String>,
-        #[arg(short = 'w', long, help = "Overwrite existing key")]
-        overwrite: bool,
-        value: Option<String>,
-        #[arg(
-            short,
-            long,
-            help = "Point to a file that will be stored, - for stdin",
-            value_name = "filename",
-            conflicts_with = "value"
-        )]
-        file: Option<String>,
-    },
-    /// Delete an existing key from the store
-    Delete { key: String },
-    /// Check if a key exists
-    Exists { key: String },
-    /// Describe CloudFormation stack params for current configuration.
-    /// This value is useful for Lambdas as you can load the CfParams from env rather than from CloudFormation.
-    DescribeStack {},
-}
+mod cli;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args: Args = parse_args().await;
+    let args: Args = cli::parse_args().await;
 
     let client = Vault::new(None, args.region.as_deref())
         .await
         .with_context(|| "Failed to create vault.".to_string())?;
 
     if args.all {
-        return list_all(&client).await;
+        return cli::list_all(&client).await;
     } else if args.describestack {
         println!("{:#?}", client.stack_info());
         return Ok(());
@@ -102,129 +25,21 @@ async fn main() -> Result<()> {
     }
 
     if let Some(key) = args.lookup.as_deref() {
-        return lookup(&client, key).await;
+        return cli::lookup(&client, key).await;
     }
 
     match &args.command {
-        Some(Commands::List {}) => list_all(&client).await,
-        Some(Commands::Load { key }) => lookup(&client, key).await,
-        Some(Commands::Store {
+        Some(Command::Delete { key }) => cli::delete(&client, key).await,
+        Some(Command::DescribeStack {}) => Ok(println!("{:#?}", client.stack_info())),
+        Some(Command::Exists { key }) => cli::exists(&client, key).await,
+        Some(Command::List {}) => cli::list_all(&client).await,
+        Some(Command::Load { key }) => cli::lookup(&client, key).await,
+        Some(Command::Store {
             key,
             value,
             overwrite,
             file,
-        }) => store(&client, key, value, file, overwrite).await,
-        Some(Commands::Exists { key }) => exists(&client, key).await,
-        Some(Commands::DescribeStack {}) => Ok(println!("{:#?}", client.stack_info())),
-        Some(Commands::Delete { key }) => delete(&client, key).await,
+        }) => cli::store(&client, key, value, file, overwrite).await,
         None => Ok(()),
     }
-}
-
-async fn parse_args() -> Args {
-    Args::parse()
-}
-
-async fn store(
-    vault: &Vault,
-    key: &Option<String>,
-    value: &Option<String>,
-    file: &Option<String>,
-    overwrite: &bool,
-) -> Result<()> {
-    let key = {
-        if let Some(key) = key {
-            key
-        } else if let Some(file_name) = file {
-            match file_name.as_str() {
-                "-" => anyhow::bail!("Key cannot be empty when reading from stdin"),
-                _ => file_name,
-            }
-        } else {
-            anyhow::bail!(
-                "Empty key and no \x1b[33m-f\x1b[0m flag provided, provide at least one of these"
-            )
-        }
-    };
-
-    let data = {
-        if let Some(value) = value {
-            value.to_owned()
-        } else if let Some(path) = file {
-            match path.as_str() {
-                "-" => {
-                    println!("Reading from stdin, empty line stops reading");
-                    stdin()
-                        .lock()
-                        .lines()
-                        .map(|l| l.unwrap())
-                        .take_while(|l| !l.trim().is_empty())
-                        .fold(String::new(), |acc, line| acc + &line + "\n")
-                }
-                _ => std::fs::read_to_string(path)
-                    .with_context(|| format!("Error reading file '{path}'"))?,
-            }
-        } else {
-            anyhow::bail!("No value or filename provided")
-        }
-    };
-
-    if !overwrite
-        && vault
-            .exists(key)
-            .await
-            .with_context(|| format!("Error checking if key {key} exists"))?
-    {
-        anyhow::bail!(
-            "Error saving key, it already exists and you did not provide \x1b[33m-w\x1b[0m flag for overwriting"
-        )
-    }
-
-    vault
-        .store(key, data.as_bytes())
-        .await
-        .with_context(|| format!("Error saving key {}", key))
-}
-
-async fn delete(vault: &Vault, key: &str) -> Result<()> {
-    if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
-    }
-    vault
-        .delete(key)
-        .await
-        .with_context(|| format!("Error deleting key '{}'.", key))
-}
-
-async fn lookup(vault: &Vault, key: &str) -> Result<()> {
-    if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
-    }
-    vault
-        .lookup(key)
-        .await
-        .with_context(|| format!("Error looking up key '{}'.", key))
-        .map(|res| print!("{res}"))
-}
-
-async fn list_all(vault: &Vault) -> Result<()> {
-    vault
-        .all()
-        .await
-        .with_context(|| "Error listing all keys".to_string())
-        .map(|list| println!("{}", list.join("\n")))
-}
-
-async fn exists(vault: &Vault, key: &str) -> Result<()> {
-    if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{}'", key)
-    }
-    vault
-        .exists(key)
-        .await
-        .with_context(|| format!("Error checking if key {key} exists"))
-        .map(|result| match result {
-            true => println!("key {key} exists"),
-            false => println!("key {key} doesn't exist"),
-        })
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result};
 
-use nitor_vault::Vault;
-
 use cli::{Args, Command};
+use nitor_vault::Vault;
 
 mod cli;
 
@@ -14,9 +13,10 @@ async fn main() -> Result<()> {
         .await
         .with_context(|| "Failed to create vault.".to_string())?;
 
+    // Handle args with no parameters
     if args.all {
         return cli::list_all(&client).await;
-    } else if args.describestack {
+    } else if args.describe {
         println!("{:#?}", client.stack_info());
         return Ok(());
     } else if args.info {
@@ -28,9 +28,10 @@ async fn main() -> Result<()> {
         return cli::lookup(&client, key).await;
     }
 
+    // Handle subcommands
     match &args.command {
         Some(Command::Delete { key }) => cli::delete(&client, key).await,
-        Some(Command::DescribeStack {}) => Ok(println!("{:#?}", client.stack_info())),
+        Some(Command::Describe {}) => Ok(println!("{:#?}", client.stack_info())),
         Some(Command::Exists { key }) => cli::exists(&client, key).await,
         Some(Command::List {}) => cli::list_all(&client).await,
         Some(Command::Load { key }) => cli::lookup(&client, key).await,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     if args.all {
         return cli::list_all(&client).await;
     } else if args.describe {
-        println!("{:#?}", client.stack_info());
+        println!("{}", client.stack_info());
         return Ok(());
     } else if args.info {
         client.test();
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     // Handle subcommands
     match &args.command {
         Some(Command::Delete { key }) => cli::delete(&client, key).await,
-        Some(Command::Describe {}) => Ok(println!("{:#?}", client.stack_info())),
+        Some(Command::Describe {}) => Ok(println!("{}", client.stack_info())),
         Some(Command::Exists { key }) => cli::exists(&client, key).await,
         Some(Command::List {}) => cli::list_all(&client).await,
         Some(Command::Load { key }) => cli::lookup(&client, key).await,


### PR DESCRIPTION
- Move Rust CLI related stuff from `main.rs` to a new `cli.rs` module
- Print help if no args or commands are given
- Rename `CfParams` to `CloudFormationParams`
- Reformat all Python arg definitions to be in same format for better readability (easier to see all the possible args)