### PR TITLE
Improve Rust vault color handling and cli options

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudformation"
-version = "1.20.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f30d0f3f4d27f0b8026c3cc32b776ccf242d34abb5c3185aa87df239abb05a"
+checksum = "0c06de789471895529897a2ae0feb30f28618e871641cc2153cf275050023026"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffff97eef0a66fb565564d27cb108cc85409aa31cd6c8e22afed7abe5ccbd403"
+checksum = "a8a5a162d74d90ad05c1c8ab2a498291ead63323dae60981002d7cdda407ab44"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.19.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54dd36a773ad90e8ae6b8464e51af0312b5422418ae1fd80c7a647975e1846b6"
+checksum = "c2090d4e1455988a3a09a3a695c66de0feef49ebbc3f87bf49a7344308bc5656"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytes-utils"
@@ -871,9 +871,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff"
@@ -1140,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -1757,9 +1757,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1996,9 +1996,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "version_check"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -53,6 +53,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +133,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b96342ea8948ab9bef3e6234ea97fc32e2d8a88d8fb6a084e52267317f94b6b"
+checksum = "4f4084d18094aec9f79d509f4cb6ccf6b613c5037e32f32e74312e52b836e366"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -133,7 +152,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "ring",
  "time",
@@ -144,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273fa47dafc9ef14c2c074ddddbea4561ff01b7f68d5091c0e9737ced605c01d"
+checksum = "fa8587ae17c8e967e4b05a62d495be2fb7701bec52a97f7acfe8a29f938384c8"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -156,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e38bab716c8bf07da24be07ecc02e0f5656ce8f30a891322ecdcb202f943b85"
+checksum = "b13dc54b4b49f8288532334bba8f87386a40571c47c37b1304979b556dc613c8"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -170,7 +189,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "percent-encoding",
  "pin-project-lite",
@@ -180,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudformation"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92a2efbc3b78ce82e83cee3abefc2fb4174da2aa587eb0edefa0cc954fc8295"
+checksum = "f2f30d0f3f4d27f0b8026c3cc32b776ccf242d34abb5c3185aa87df239abb05a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -196,7 +215,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -204,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e80e0fd041ff93df03e2c1735c44bef9eecf3e7b3a4928f9beebedaeeaa95a4"
+checksum = "ffff97eef0a66fb565564d27cb108cc85409aa31cd6c8e22afed7abe5ccbd403"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -218,7 +237,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -226,10 +245,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.17.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d35d39379445970fc3e4ddf7559fff2c32935ce0b279f9cb27080d6b7c6d94"
+checksum = "54dd36a773ad90e8ae6b8464e51af0312b5422418ae1fd80c7a647975e1846b6"
 dependencies = [
+ "ahash",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -244,20 +264,25 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
  "http-body",
+ "lru",
  "once_cell",
  "percent-encoding",
  "regex-lite",
+ "sha2",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84bd3925a17c9adbf6ec65d52104a44a09629d8f70290542beeee69a95aee7f"
+checksum = "c5cc34f5925899739a3f125bd3f7d37d081234a3df218feb9c9d337fd4c70e72"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -269,7 +294,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -277,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2dae39e997f58bc4d6292e6244b26ba630c01ab671b6f9f44309de3eb80ab8"
+checksum = "7327cddd32b1a6f2aaeaadb1336b671a7975e96a999d3b1bcf5aa47932dc6ddb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -291,7 +316,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -299,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fd9a53869fee17cea77e352084e1aa71e2c5e323d974c13a9c2bcfd9544c7f"
+checksum = "6c11981cdb80e8e205e22beb6630a8bdec380a1256bd29efaab34aaebd07cfb9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -314,7 +339,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -322,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.1.7"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada00a4645d7d89f296fe0ddbc3fe3554f03035937c849a05d37ddffc1f29a1"
+checksum = "11d6f29688a4be9895c0ba8bef861ad0c0dac5c15e9618b9b7a6c233990fc263"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -336,8 +361,8 @@ dependencies = [
  "form_urlencoded",
  "hex",
  "hmac",
- "http 0.2.11",
- "http 1.0.0",
+ "http 0.2.12",
+ "http 1.1.0",
  "once_cell",
  "p256",
  "percent-encoding",
@@ -351,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf7f09a27286d84315dfb9346208abb3b0973a692454ae6d0bc8d803fcce3b4"
+checksum = "d26ea8fa03025b2face2b3038a63525a10891e3d8829901d502e5384a0d8cd46"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -362,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd4b66f2a8e7c84d7e97bda2666273d41d2a2e25302605bcf906b7b2661ae5e"
+checksum = "83fa43bc04a6b2441968faeab56e68da3812f978a670a5db32accbdcafddd12f"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -372,7 +397,7 @@ dependencies = [
  "crc32c",
  "crc32fast",
  "hex",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "md-5",
  "pin-project-lite",
@@ -394,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ca214a6a26f1b7ebd63aa8d4f5e2194095643023f9608edf99a58247b9d80d"
+checksum = "3f10fa66956f01540051b0aa7ad54574640f748f9839e843442d99b970d3aff9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -404,7 +429,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "once_cell",
  "percent-encoding",
@@ -415,18 +440,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af80ecf3057fb25fe38d1687e94c4601a7817c6a1e87c1b0635f7ecb644ace5"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb27084f72ea5fc20033efe180618677ff4a2f474b53d84695cfe310a6526cbc"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -434,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb5fca54a532a36ff927fbd7407a7c8eb9c3b4faf72792ba2965ea2cad8ed55"
+checksum = "ec81002d883e5a7fd2bb063d6fb51c4999eb55d404f4fff3dd878bf4733b9f01"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -445,7 +470,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -459,15 +484,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.1.7"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22389cb6f7cac64f266fb9f137745a9349ced7b47e0d2ba503e9e40ede4f7060"
+checksum = "9acb931e0adaf5132de878f1398d83f8677f90ba70f01f65ff87f6d7244be1c5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
- "http 0.2.11",
- "http 1.0.0",
+ "http 0.2.12",
+ "http 1.1.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -476,15 +501,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f081da5481210523d44ffd83d9f0740320050054006c719eae0232d411f024d3"
+checksum = "abe14dceea1e70101d38fbf2a99e6a34159477c0fb95e68e05c66bd7ae4c3729"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "itoa",
  "num-integer",
@@ -499,24 +524,24 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fccd8f595d0ca839f9f2548e66b99514a85f92feb4c01cf2868d93eb4888a42"
+checksum = "872c68cf019c0e4afc5de7753c4f7288ce4b71663212771bf5e4542eb9346ca9"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07c63521aa1ea9a9f92a701f1a08ce3fd20b46c6efc0d5c8947c1fd879e3df1"
+checksum = "0dbf2f3da841a8930f159163175cf6a3d16ddde517c1b0fba7aa776822800f40"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.11",
+ "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -603,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -668,6 +693,16 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "const-oid"
@@ -927,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -954,16 +989,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -976,6 +1011,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1006,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1017,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1033,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -1060,7 +1099,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -1080,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "log",
  "rustls",
@@ -1125,6 +1164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1190,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "md-5"
@@ -1184,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1194,6 +1248,7 @@ dependencies = [
  "aws-sdk-s3",
  "base64 0.22.0",
  "clap",
+ "colored",
  "rand",
  "serde",
  "serde_json",
@@ -1332,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1356,9 +1411,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1702,9 +1757,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2109,6 +2164,26 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,9 +15,9 @@ authors = [
 aes-gcm = "0.10.3"
 anyhow = "1.0.81"
 aws-config = { version = "1.1.8", features = ["behavior-version-latest"] }
-aws-sdk-cloudformation = "1.20.0"
-aws-sdk-kms = "1.17.0"
-aws-sdk-s3 = "1.19.1"
+aws-sdk-cloudformation = "1.21.1"
+aws-sdk-kms = "1.18.0"
+aws-sdk-s3 = "1.20.0"
 base64 = "0.22.0"
 clap = { version = "4.5.3", features = ["derive", "env"] }
 colored = "2.1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,30 +1,31 @@
 [package]
 name = "nitor-vault"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility."
 license = "Apache-2.0"
 repository = "https://github.com/nitorcreations/vault"
 keywords = ["secrets", "s3", "cli"]
 authors = [
-  "Kalle Ahlström <kalle.ahlstrom@nitor.com",
-  "Akseli Lukkarila <akseli.lukkarila@nitor.com>",
+    "Kalle Ahlström <kalle.ahlstrom@nitor.com",
+    "Akseli Lukkarila <akseli.lukkarila@nitor.com>",
 ]
 
 [dependencies]
 aes-gcm = "0.10.3"
 anyhow = "1.0.81"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-cloudformation = "1.17.0"
-aws-sdk-kms = "1.15.0"
-aws-sdk-s3 = "1.17.0"
+aws-config = { version = "1.1.8", features = ["behavior-version-latest"] }
+aws-sdk-cloudformation = "1.20.0"
+aws-sdk-kms = "1.17.0"
+aws-sdk-s3 = "1.19.1"
 base64 = "0.22.0"
 clap = { version = "4.5.3", features = ["derive", "env"] }
+colored = "2.1.0"
 rand = "0.8.5"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 thiserror = "1.0.58"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.36.0", features = ["full"] }
 
 [[bin]]
 name = "vault"

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,6 +3,28 @@
 Rust CLI and library for encrypting keys and values using client-side encryption
 with [AWS KMS](https://aws.amazon.com/kms/) keys.
 
+```console
+Usage: vault [OPTIONS] [COMMAND]
+
+Commands:
+  delete, -d, --delete  Delete an existing key from the store
+  describe, --describe  Describe CloudFormation stack parameters for current configuration
+  exists, -e, --exists  Check if a key exists
+  all, -a, --all        List available secrets
+  lookup, -l, --lookup  Print secret value for given key
+  store, -s, --store    Store a new key-value pair
+  info, -i, --info      Print region and stack information
+  help                  Print this message or the help of the given subcommand(s)
+
+Options:
+  -b, --bucket <BUCKET>            Override the bucket name [env: VAULT_BUCKET=]
+  -k, --key-arn <KEY_ARN>          Override the KMS key arn for storing or looking up [env: VAULT_KEY=]
+  -r, --region <REGION>            Specify AWS region for the bucket [env: AWS_REGION=]
+      --vault-stack <VAULT_STACK>  Optional CloudFormation stack to lookup key and bucket [env: VAULT_STACK=]
+  -h, --help                       Print help (see more with '--help')
+  -V, --version                    Print version
+```
+
 ## Build
 
 Using the shell script:

--- a/rust/README.md
+++ b/rust/README.md
@@ -25,6 +25,8 @@ Options:
   -V, --version                    Print version
 ```
 
+ANSI color output can be disabled by setting the env variable `NO_COLOR=1`.
+
 ## Build
 
 Using the shell script:

--- a/rust/build.sh
+++ b/rust/build.sh
@@ -8,13 +8,13 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../common.sh
 source "$DIR/../common.sh"
 
-print_magenta "Building vault binary (Rust)..."
+print_magenta "Building Rust vault binary..."
 
 if [ -z "$(command -v cargo)" ]; then
     print_error_and_exit "Cargo not found in path. Maybe install rustup?"
 fi
 
-pushd "$DIR" > /dev/null
+cd "$DIR"
 cargo build --release
 
 if [ "$PLATFORM" = windows ]; then
@@ -27,4 +27,3 @@ rm -f "$executable"
 mv ./target/release/"$executable" "$executable"
 file "$executable"
 ./"$executable" --version
-popd > /dev/null

--- a/rust/install.sh
+++ b/rust/install.sh
@@ -21,6 +21,5 @@ if [ -z "$(command -v vault)" ]; then
 fi
 
 print_magenta "Checking version..."
-
 echo "First in path: $(vault --version) from $(which vault)"
 echo "Rust binary:   $("$HOME/.cargo/bin/vault" --version) from $(which "$HOME/.cargo/bin/vault")"

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -204,6 +204,6 @@ pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
         .context(format!("Failed to check if key '{key}' exists").red())
         .map(|result| match result {
             true => println!("key '{key}' exists"),
-            false => println!("{}", format!("key '{key}' does not exist").red()),
+            false => println!("{}", format!("key '{key}' doesn't exist").red()),
         })
 }

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -164,7 +164,7 @@ pub async fn store(
 /// Delete key value
 pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{key}'".red())
+        anyhow::bail!(format!("Empty key '{key}'").red())
     }
     vault
         .delete(key)
@@ -175,7 +175,7 @@ pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
 /// Get key value
 pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key '{key}'".red())
+        anyhow::bail!(format!("Empty key '{key}'").red())
     }
     vault
         .lookup(key)
@@ -196,7 +196,7 @@ pub async fn list_all(vault: &Vault) -> Result<()> {
 /// Check if key exists
 pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
-        anyhow::bail!("Empty key: '{key}'".red())
+        anyhow::bail!(format!("Empty key: '{key}'").red())
     }
     vault
         .exists(key)

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -136,7 +136,7 @@ pub async fn store(
                         .fold(String::new(), |acc, line| acc + &line + "\n")
                 }
                 _ => std::fs::read_to_string(path)
-                    .context(format!("Error reading file: '{path}'").red())?,
+                    .with_context(|| format!("Error reading file: '{path}'").red())?,
             }
         } else {
             anyhow::bail!("No value or filename provided".red())
@@ -147,7 +147,7 @@ pub async fn store(
         && vault
             .exists(key)
             .await
-            .context(format!("Failed to check if key '{key}' exists").red())?
+            .with_context(|| format!("Failed to check if key '{key}' exists").red())?
     {
         anyhow::bail!(
             "Key already exists and no {} flag provided for overwriting",
@@ -158,7 +158,7 @@ pub async fn store(
     vault
         .store(key, data.as_bytes())
         .await
-        .context(format!("Failed to store key '{key}'").red())
+        .with_context(|| format!("Failed to store key '{key}'").red())
 }
 
 /// Delete key value
@@ -169,7 +169,7 @@ pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
     vault
         .delete(key)
         .await
-        .context(format!("Failed to delete key '{key}'").red())
+        .with_context(|| format!("Failed to delete key '{key}'").red())
 }
 
 /// Get key value
@@ -180,7 +180,7 @@ pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
     vault
         .lookup(key)
         .await
-        .context(format!("Failed to look up key '{key}'").red())
+        .with_context(|| format!("Failed to look up key '{key}'").red())
         .map(|res| print!("{res}"))
 }
 
@@ -189,7 +189,7 @@ pub async fn list_all(vault: &Vault) -> Result<()> {
     vault
         .all()
         .await
-        .context("Failed to list all keys".red())
+        .with_context(|| "Failed to list all keys".red())
         .map(|list| println!("{}", list.join("\n")))
 }
 
@@ -201,7 +201,7 @@ pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
     vault
         .exists(key)
         .await
-        .context(format!("Failed to check if key '{key}' exists").red())
+        .with_context(|| format!("Failed to check if key '{key}' exists").red())
         .map(|result| match result {
             true => println!("key '{key}' exists"),
             false => println!("{}", format!("key '{key}' doesn't exist").red()),

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -147,10 +147,10 @@ pub async fn store(
         && vault
             .exists(key)
             .await
-            .context(format!("Error checking if key '{key}' exists").red())?
+            .context(format!("Failed to check if key '{key}' exists").red())?
     {
         anyhow::bail!(
-            "Error saving key, it already exists and you did not provide {} flag for overwriting",
+            "Key already exists and no {} flag provided for overwriting",
             "-w".yellow().bold()
         )
     }
@@ -158,7 +158,7 @@ pub async fn store(
     vault
         .store(key, data.as_bytes())
         .await
-        .context(format!("Error saving key '{key}'").red())
+        .context(format!("Failed to store key '{key}'").red())
 }
 
 /// Delete key value
@@ -169,7 +169,7 @@ pub async fn delete(vault: &Vault, key: &str) -> Result<()> {
     vault
         .delete(key)
         .await
-        .context(format!("Error deleting key '{key}'").red())
+        .context(format!("Failed to delete key '{key}'").red())
 }
 
 /// Get key value
@@ -180,7 +180,7 @@ pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
     vault
         .lookup(key)
         .await
-        .context(format!("Error looking up key '{key}'").red())
+        .context(format!("Failed to look up key '{key}'").red())
         .map(|res| print!("{res}"))
 }
 
@@ -189,7 +189,7 @@ pub async fn list_all(vault: &Vault) -> Result<()> {
     vault
         .all()
         .await
-        .context("Error listing all keys".red())
+        .context("Failed to list all keys".red())
         .map(|list| println!("{}", list.join("\n")))
 }
 
@@ -201,7 +201,7 @@ pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
     vault
         .exists(key)
         .await
-        .context(format!("Error checking if key '{key}' exists").red())
+        .context(format!("Failed to check if key '{key}' exists").red())
         .map(|result| match result {
             true => println!("key '{key}' exists"),
             false => println!("{}", format!("key '{key}' does not exist").red()),

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -9,6 +9,7 @@ use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
 use aws_sdk_s3::operation::put_object::PutObjectError;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -17,13 +18,13 @@ pub enum VaultError {
     DescribeStackError(#[from] SdkError<DescribeStacksError>),
     #[error("CloudFormation Stack outputs missing")]
     StackOutputsMissingError,
-    #[error("Error getting bucket name from stack")]
+    #[error("Failed to get bucket name from stack")]
     BucketNameMissingError,
     #[error("No KEY_ARN provided, can't encrypt")]
     KeyARNMissingError,
-    #[error("Error Generating KMS Data key")]
+    #[error("Failed to generate KMS Data key")]
     KMSGenerateDataKeyError(#[from] SdkError<GenerateDataKeyError>),
-    #[error("Error decrypting Ciphertext with KMS")]
+    #[error("Failed to decrypt Ciphertext with KMS")]
     KMSDecryptError(#[from] SdkError<DecryptError>),
     #[error("No Plaintext for generated datakey")]
     KMSDataKeyPlainTextMissingError,
@@ -33,30 +34,30 @@ pub enum VaultError {
     InvalidNonceLengthError(#[from] aes_gcm::aes::cipher::InvalidLength),
     #[error("Invalid length for encryption cipher")]
     NonceDecryptError,
-    #[error("Error, string not valid UTF8")]
+    #[error("String is not valid UTF8")]
     NonUtf8BodyError(#[from] FromUtf8Error),
-    #[error("Error encrypting ciphertext")]
+    #[error("Failed to encrypt ciphertext")]
     CiphertextEncryptionError,
-    #[error("Error parsing meta with serde")]
+    #[error("Failed to parse meta with serde")]
     EncryptObjectMetaToJsonError(#[from] serde_json::Error),
     #[error("Failed getting object from S3")]
     S3GetObjectError(#[from] SdkError<GetObjectError>),
     #[error("Failed deleting object from S3")]
     S3DeleteObjectError(#[from] SdkError<DeleteObjectError>),
-    #[error("Key not existing in S3")]
+    #[error("Key does not exist in S3")]
     S3DeleteObjectKeyMissingError,
     #[error("Failed getting head-object from S3")]
     S3HeadObjectError(#[from] HeadObjectError),
-    #[error("Error decrypting S3-object body")]
+    #[error("Failed to decrypt S3-object body")]
     S3GetObjectBodyError,
-    #[error("Error putting object to S3")]
+    #[error("Failed putting object to S3")]
     S3PutObjectError(#[from] SdkError<PutObjectError>),
-    #[error("Error listing S3 objects")]
+    #[error("Failed to list S3 objects")]
     S3ListObjectsError(#[from] SdkError<ListObjectsV2Error>),
     #[error("No contents found from S3")]
     S3NoContentsError,
-    #[error("Error getting region")]
+    #[error("Failed getting region")]
     NoRegionError,
-    #[error("Error parsing Nonce from base64")]
+    #[error("Failed parsing Nonce from base64")]
     NonceParseError(#[from] base64::DecodeError),
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -130,11 +130,6 @@ impl Vault {
         })
     }
 
-    /// Print information: region and CloudFormation parameters.
-    pub fn print_info(&self) {
-        println!("region: {}\n{}", self.region, self.cloudformation_params);
-    }
-
     /// Get all available secrets
     pub async fn all(&self) -> Result<Vec<String>, VaultError> {
         let output = self
@@ -362,6 +357,12 @@ async fn get_cloudformation_params(
         key_arn: parse_output_value_from_key("kmsKeyArn", stack_output),
         // deployed_version: parse_output_value_from_key("vaultStackVersion", &stack_output),
     })
+}
+
+impl fmt::Display for Vault {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "region: {}\n{}", self.region, self.cloudformation_params)
+    }
 }
 
 fn get_region_provider(region_opt: Option<&str>) -> RegionProviderChain {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod errors;
+
 use std::env;
 use std::fmt;
 
@@ -16,16 +18,16 @@ use aws_sdk_s3::operation::put_object::PutObjectOutput;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as s3Client;
 use base64::{engine::general_purpose, Engine as _};
-use errors::VaultError;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::try_join;
 
-pub mod errors;
+use crate::errors::VaultError;
 
 #[derive(Debug)]
 pub struct Vault {
-    /// AWS region to use with Vault. Will fallback to default provider if nothing is specified.
+    /// AWS region to use with Vault.
+    /// Will fall back to default provider if nothing is specified.
     region: Region,
     cloudformation_params: CloudFormationParams,
     s3: s3Client,
@@ -128,12 +130,9 @@ impl Vault {
         })
     }
 
-    /// Print debug information: region, CloudFormation parameters and S3 client.
-    pub fn test(&self) {
-        println!(
-            "region: {}\nvault_stack: {:#?}\ns3: {:#?}",
-            self.region, self.cloudformation_params, self.s3
-        );
+    /// Print information: region and CloudFormation parameters.
+    pub fn print_info(&self) {
+        println!("region: {}\n{}", self.region, self.cloudformation_params);
     }
 
     /// Get all available secrets

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,13 +1,15 @@
 mod cli;
 
 use anyhow::{Context, Result};
+use colored::Colorize;
 
 use crate::cli::{Args, Command};
+
 use nitor_vault::{CloudFormationParams, Vault};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args: Args = cli::parse_args().await;
+    let args: Args = cli::parse_args();
 
     // Bucket and key were either given as args or found in env variables
     let client = if args.bucket.is_some() && args.key_arn.is_some() {
@@ -16,11 +18,11 @@ async fn main() -> Result<()> {
             args.region.as_deref(),
         )
         .await
-        .context("Failed to create vault from given params.")?
+        .context("Failed to create vault from given params".red())?
     } else {
         Vault::new(args.vault_stack.as_deref(), args.region.as_deref())
             .await
-            .context("Failed to create vault.")?
+            .context("Failed to create vault".red())?
     };
 
     // Handle subcommands
@@ -28,7 +30,7 @@ async fn main() -> Result<()> {
         return match command {
             Command::Delete { key } => cli::delete(&client, &key).await,
             Command::Describe {} => Ok(println!("{}", client.stack_info())),
-            Command::Exists { key } => cli::exists(&client, key).await,
+            Command::Exists { key } => cli::exists(&client, &key).await,
             Command::All {} => cli::list_all(&client).await,
             Command::Lookup { key } => cli::lookup(&client, &key).await,
             Command::Store {
@@ -38,7 +40,10 @@ async fn main() -> Result<()> {
                 file,
                 value_opt,
             } => cli::store(&client, key, value, file, value_opt, overwrite).await,
-            Command::Info {} => Ok(println!("{}", client.stack_info())),
+            Command::Info {} => {
+                client.print_info();
+                Ok(())
+            }
         };
     }
     Ok(())

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -18,11 +18,13 @@ async fn main() -> Result<()> {
             args.region.as_deref(),
         )
         .await
-        .context("Failed to create vault from given params".red())?
+        // Note: `with_context` is used instead of the simpler `context`
+        // as it is lazily evaluated.
+        .with_context(|| "Failed to create vault from given params".red())?
     } else {
         Vault::new(args.vault_stack.as_deref(), args.region.as_deref())
             .await
-            .context("Failed to create vault".red())?
+            .with_context(|| "Failed to create vault".red())?
     };
 
     // Handle subcommands

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -40,10 +40,7 @@ async fn main() -> Result<()> {
                 file,
                 value_opt,
             } => cli::store(&client, key, value, file, value_opt, overwrite).await,
-            Command::Info {} => {
-                client.print_info();
-                Ok(())
-            }
+            Command::Info {} => Ok(println!("{}", client)),
         };
     }
     Ok(())


### PR DESCRIPTION
- Use `colored` crate for handling ANSI colors instead of manually specifying codes
- Add a few missing long and short argument / command options
- `Describe` and `Info` options were doing the same thing, add region to info print with repurposed debug function
- `cli::exists` function takes a reference like other methods instead of moving the string
- Add usage to readme
- Use red color for error messages and tweak error texts to avoid repeating "Error: Error..."
- Simplify anyhow context usage
- Update all crate versions in cargo.toml

Usage changes:
<img width="1246" alt="Screenshot 2024-03-19 at 10 27 12" src="https://github.com/NitorCreations/vault/assets/16880853/edf2218b-ac36-4902-aec5-98cc739a8b68">

New info option:
<img width="717" alt="Screenshot 2024-03-19 at 10 13 31" src="https://github.com/NitorCreations/vault/assets/16880853/be411424-29ab-4ad5-95a5-f72415e8c429">


Error colors and text changes:
<img width="614" alt="Screenshot 2024-03-19 at 10 31 05" src="https://github.com/NitorCreations/vault/assets/16880853/9facbe30-a825-40fc-a67b-8900047a9187">
<img width="490" alt="Screenshot 2024-03-19 at 10 13 10" src="https://github.com/NitorCreations/vault/assets/16880853/6e66aa0b-afda-401e-aa6c-e7310039daf6">
Old:
<img width="456" alt="Screenshot 2024-03-19 at 10 13 00" src="https://github.com/NitorCreations/vault/assets/16880853/ee84e9f3-a92c-4cd3-babe-eb7726ad9d8e">


Colors can be disabled by setting `NO_COLOR=1`:
<img width="466" alt="Screenshot 2024-03-19 at 10 34 42" src="https://github.com/NitorCreations/vault/assets/16880853/8173301c-cfe6-4571-8872-abfe7f43c540">

