### PR TITLE
Rust Lookup binary data

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -40,6 +40,14 @@ source .venv/bin/activate
 .venv\Scripts\activate
 ```
 
+The vault CLI can be run without installing using:
+
+```shell
+uv run python n_vault/cli.py
+# or with venv activated
+python3 n_vault/cli.py
+```
+
 ## Release
 
 Use the provided shell script.

--- a/python/n_vault/cli.py
+++ b/python/n_vault/cli.py
@@ -264,3 +264,7 @@ def main():
                 vlt.update()
     finally:
         stop_cov(None, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "shlex",
 ]
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1032,6 +1032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,12 +1184,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1241,7 +1247,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1283,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitor-vault"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility."
 license = "Apache-2.0"

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -188,10 +188,13 @@ pub async fn lookup(vault: &Vault, key: &str) -> Result<()> {
     if key.trim().is_empty() {
         anyhow::bail!(format!("Empty key '{key}'").red())
     }
-    Box::pin(vault.lookup(key))
+
+    let result = Box::pin(vault.lookup(key))
         .await
-        .with_context(|| format!("Failed to look up key '{key}'").red())
-        .map(|res| print!("{res}"))
+        .with_context(|| format!("Failed to look up key '{key}'").red())?;
+
+    result.output_to_stdout()?;
+    Ok(())
 }
 
 /// List all available keys

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod errors;
 
-use std::env;
 use std::fmt;
+use std::io::Write;
+use std::{env, io};
 
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::aes::{cipher, Aes256};
@@ -75,6 +76,24 @@ impl Data {
         match self {
             Self::Utf8(ref string) => string.as_bytes(),
             Self::Binary(ref bytes) => bytes,
+        }
+    }
+
+    /// Outputs the data directly to stdout.
+    /// String data is printed.
+    /// Binary data is outputted raw.
+    pub fn output_to_stdout(&self) -> io::Result<()> {
+        match self {
+            Self::Utf8(ref string) => {
+                println!("{string}");
+                Ok(())
+            }
+            Self::Binary(ref bytes) => {
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                handle.write_all(bytes)?;
+                handle.flush()
+            }
         }
     }
 }


### PR DESCRIPTION
Implement https://github.com/NitorCreations/vault/issues/246

- Support lookup for non UTF-8 data
- Support storing non UTF-8 data when storing a file
- Support storing non UTF-8 data from stdin

For example this works now and produces a working archive that can be extracted:

```console
./vault lookup chat-letsencrypt.tar.gz > test.tar.gz
```

Other examples:

```console
 ./vault store binarytest --file ../k-ruoka-bot-detection.pdf --overwrite
./vault lookup binarytest > test.pdf
# ^ pdf works 

➜  rust git:(lookup-binary-data) ✗ cat ~/Documents/Lukkarila\ Akseli.xlsx | ./vault store xlsxtest --file -
Reading from stdin until EOF

./vault lookup xlsxtest > test.xlsx
# ^ excel works
```