### PR TITLE
Rust: reorganize library code

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitor-vault"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility."
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ aws-sdk-cloudformation = "1.30.0"
 aws-sdk-kms = "1.26.0"
 aws-sdk-s3 = "1.29.0"
 base64 = "0.22.1"
-clap = { version = "4.5.18", features = ["derive", "env"] }
+clap = { version = "4.5.19", features = ["derive", "env"] }
 colored = "2.1.0"
 rand = "0.8.5"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -4,8 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-use nitor_vault::Value;
-use nitor_vault::Vault;
+use nitor_vault::{Value, Vault};
 
 /// Store a key-value pair
 pub async fn store(

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -2,130 +2,10 @@ use std::io::{stdin, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
 use colored::Colorize;
 
-use nitor_vault::{Data, Vault};
-
-#[allow(clippy::doc_markdown)]
-#[derive(Parser)]
-#[command(
-    author,
-    version,
-    about,
-    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples",
-    arg_required_else_help = true
-)] // Reads info from `Cargo.toml`
-pub struct Args {
-    /// Override the bucket name
-    #[arg(short, long, env = "VAULT_BUCKET")]
-    pub bucket: Option<String>,
-
-    /// Override the KMS key arn for storing or looking up
-    #[arg(short, long, env = "VAULT_KEY")]
-    pub key_arn: Option<String>,
-
-    /// Specify AWS region for the bucket
-    #[arg(short, long, env = "AWS_REGION")]
-    pub region: Option<String>,
-
-    /// Optional CloudFormation stack to lookup key and bucket
-    #[arg(long, env)]
-    pub vault_stack: Option<String>,
-
-    /// Available subcommands
-    #[command(subcommand)]
-    pub command: Option<Command>,
-}
-
-#[allow(clippy::doc_markdown)]
-#[derive(Subcommand)]
-pub enum Command {
-    /// Delete an existing key from the store
-    #[command(short_flag('d'), long_flag("delete"))]
-    Delete { key: String },
-
-    /// Describe CloudFormation stack parameters for current configuration.
-    // This value is useful for Lambdas as you can load the CloudFormation parameters from env.
-    #[command(long_flag("describe"))]
-    Describe {},
-
-    /// Check if a key exists
-    #[command(short_flag('e'), long_flag("exists"), alias("e"))]
-    Exists { key: String },
-
-    /// List available secrets
-    #[command(short_flag('a'), long_flag("all"), alias("a"))]
-    All {},
-
-    /// Output secret value for given key
-    #[command(short_flag('l'), long_flag("lookup"), alias("l"))]
-    Lookup {
-        /// Key name to lookup
-        key: String,
-
-        /// Optional output file
-        #[arg(short, long, value_name = "filepath")]
-        outfile: Option<String>,
-    },
-
-    /// Store a new key-value pair
-    #[command(
-        short_flag('s'),
-        long_flag("store"),
-        alias("s"),
-        long_about = "Store a new key-value pair in the vault.\n\
-                      You can provide the key and value directly, or specify a file to store.\n\n\
-                      Usage examples:\n\
-                      - Store a value: `vault store mykey \"some value\"`\n\
-                      - Store a value from args: `vault store mykey --value \"some value\"`\n\
-                      - Store from a file: `vault store mykey --file path/to/file.txt`\n\
-                      - Store from a file with filename as key: `vault store --file path/to/file.txt`\n\
-                      - Store from stdin: `echo \"some data\" | vault store mykey --value -`\n\
-                      - Store from stdin: `cat file.zip | vault store mykey --file -`"
-    )]
-    Store {
-        /// Key name
-        key: Option<String>,
-
-        /// Value to store
-        value: Option<String>,
-
-        /// Overwrite existing key
-        #[arg(short = 'w', long)]
-        overwrite: bool,
-
-        /// Value to store, use '-' for stdin
-        #[arg(
-            short,
-            long = "value",
-            value_name = "value",
-            conflicts_with_all = vec!["value", "file"]
-        )]
-        value_argument: Option<String>,
-
-        /// File to store, use '-' for stdin
-        #[arg(
-            short,
-            long,
-            value_name = "filepath",
-            conflicts_with_all = vec!["value", "value_opt"]
-        )]
-        file: Option<String>,
-    },
-
-    /// Print region and stack information
-    #[command(short_flag('i'), long_flag("info"), alias("i"))]
-    Info {},
-}
-
-/// Parse command line arguments.
-///
-/// See Clap `Derive` documentation for details:
-/// <https://docs.rs/clap/latest/clap/_derive/index.html>
-pub fn parse_args() -> Args {
-    Args::parse()
-}
+use nitor_vault::Value;
+use nitor_vault::Vault;
 
 /// Store a key-value pair
 pub async fn store(
@@ -160,7 +40,7 @@ pub async fn store(
                 println!("Reading from stdin until EOF");
                 read_data_from_stdin()?
             } else {
-                Data::Utf8(value)
+                Value::Utf8(value)
             }
         } else if let Some(path) = &file {
             match path.as_str() {
@@ -222,7 +102,7 @@ pub async fn lookup(vault: &Vault, key: &str, outfile: Option<String>) -> Result
 }
 
 /// List all available keys
-pub async fn list_all(vault: &Vault) -> Result<()> {
+pub async fn list_all_keys(vault: &Vault) -> Result<()> {
     vault
         .all()
         .await
@@ -249,19 +129,19 @@ pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
 }
 
 /// Read data from filepath, supporting both UTF-8 and non-UTF-8 contents
-fn read_data_from_path(path: &String) -> Result<Data> {
+fn read_data_from_path(path: &String) -> Result<Value> {
     if let Ok(content) = std::fs::read_to_string(path) {
-        Ok(Data::Utf8(content))
+        Ok(Value::Utf8(content))
     } else {
         let binary_data =
             std::fs::read(path).with_context(|| format!("Error reading file: '{path}'").red())?;
 
-        Ok(Data::Binary(binary_data))
+        Ok(Value::Binary(binary_data))
     }
 }
 
 /// Read data from stdin, supporting both UTF-8 and non-UTF-8 input
-pub fn read_data_from_stdin() -> Result<Data> {
+fn read_data_from_stdin() -> Result<Value> {
     let mut buffer = Vec::new();
 
     let stdin = stdin();
@@ -278,8 +158,8 @@ pub fn read_data_from_stdin() -> Result<Data> {
     #[allow(clippy::option_if_let_else)]
     // ^using `map_or` would require cloning buffer
     match std::str::from_utf8(&buffer) {
-        Ok(valid_utf8) => Ok(Data::Utf8(valid_utf8.to_string())),
-        Err(_) => Ok(Data::Binary(buffer)),
+        Ok(valid_utf8) => Ok(Value::Utf8(valid_utf8.to_string())),
+        Err(_) => Ok(Value::Binary(buffer)),
     }
 }
 
@@ -304,7 +184,7 @@ fn get_filename_from_path(path: &str) -> Result<String> {
 /// Resolves an optional output file path and creates all directories if necessary.
 /// Returns `Some(PathBuf)` if the file path is valid,
 /// or `None` if a file path was not provided.
-pub fn resolve_output_file_path(outfile: Option<String>) -> Result<Option<PathBuf>> {
+fn resolve_output_file_path(outfile: Option<String>) -> Result<Option<PathBuf>> {
     if let Some(output) = outfile {
         let path = PathBuf::from(output);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,10 +2,6 @@ pub mod errors;
 mod value;
 mod vault;
 
-// Expose `Vault` and `Value` so they can be used as if they were defined here
-pub use crate::value::Value;
-pub use crate::vault::Vault;
-
 use std::fmt;
 
 use aws_config::SdkConfig;
@@ -16,6 +12,10 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::VaultError;
+
+// Expose `Vault` and `Value` so they can be used as if they were defined here
+pub use crate::value::Value;
+pub use crate::vault::Vault;
 
 #[derive(Debug, Clone)]
 pub struct CloudFormationParams {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,40 +1,23 @@
 pub mod errors;
+mod value;
+mod vault;
+
+// Expose `Vault` and `Value` so they can be used as if they were defined here
+pub use crate::value::Value;
+pub use crate::vault::Vault;
 
 use std::env;
 use std::fmt;
-use std::io::{self, BufWriter, Write};
-use std::path::Path;
 
-use aes_gcm::aead::{Aead, Payload};
-use aes_gcm::aes::{cipher, Aes256};
-use aes_gcm::{AesGcm, KeyInit, Nonce};
 use aws_config::meta::region::RegionProviderChain;
 use aws_config::{Region, SdkConfig};
 use aws_sdk_cloudformation::types::Output;
 use aws_sdk_cloudformation::Client as CloudFormationClient;
-use aws_sdk_kms::primitives::Blob;
-use aws_sdk_kms::types::DataKeySpec;
-use aws_sdk_kms::Client as KmsClient;
-use aws_sdk_s3::operation::put_object::PutObjectOutput;
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::types::{Delete, ObjectIdentifier};
-use aws_sdk_s3::Client as S3Client;
+use aws_sdk_s3::types::ObjectIdentifier;
 use base64::Engine;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
-use tokio::try_join;
 
 use crate::errors::VaultError;
-
-#[derive(Debug)]
-pub struct Vault {
-    /// AWS region to use with Vault.
-    /// Will fall back to default provider if nothing is specified.
-    region: Region,
-    cloudformation_params: CloudFormationParams,
-    s3: S3Client,
-    kms: KmsClient,
-}
 
 #[derive(Debug, Clone)]
 pub struct CloudFormationParams {
@@ -47,14 +30,6 @@ struct EncryptObject {
     data_key: Vec<u8>,
     aes_gcm_ciphertext: Vec<u8>,
     meta: String,
-}
-
-#[derive(Debug, Clone)]
-/// Vault supports storing arbitrary data that might not be valid UTF-8.
-/// Support looking up data as either UTF-8 or binary.
-pub enum Data {
-    Utf8(String),
-    Binary(Vec<u8>),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -70,48 +45,14 @@ struct S3DataKeys {
     meta: String,
 }
 
-impl Data {
-    /// Returns the data as a byte slice (`&[u8]`)
-    #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
-        match self {
-            Self::Utf8(ref string) => string.as_bytes(),
-            Self::Binary(ref bytes) => bytes,
-        }
-    }
+/// Get AWS region from optional argument or fallback to default
+fn get_region_provider(region: Option<&str>) -> RegionProviderChain {
+    RegionProviderChain::first_try(region.map(|r| Region::new(r.to_owned()))).or_default_provider()
+}
 
-    /// Outputs the data directly to stdout.
-    /// String data is printed.
-    /// Binary data is outputted raw.
-    pub fn output_to_stdout(&self) -> io::Result<()> {
-        match self {
-            Self::Utf8(ref string) => {
-                print!("{string}");
-                Ok(())
-            }
-            Self::Binary(ref bytes) => {
-                let stdout = io::stdout();
-                let mut handle = stdout.lock();
-                handle.write_all(bytes)?;
-                handle.flush()
-            }
-        }
-    }
-
-    /// Outputs the data to the specified file path.
-    pub fn output_to_file(&self, path: &Path) -> io::Result<()> {
-        let file = std::fs::File::create(path)?;
-        let mut writer = BufWriter::new(file);
-        match self {
-            Self::Utf8(ref string) => {
-                writer.write_all(string.as_bytes())?;
-            }
-            Self::Binary(ref bytes) => {
-                writer.write_all(bytes)?;
-            }
-        }
-        writer.flush()
-    }
+/// Return possible env variable value as Option
+fn get_env_variable(name: &str) -> Option<String> {
+    env::var(name).ok()
 }
 
 impl CloudFormationParams {
@@ -202,26 +143,6 @@ impl S3DataKeys {
     }
 }
 
-impl fmt::Display for Vault {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "region: {}\n{}", self.region, self.cloudformation_params)
-    }
-}
-
-impl fmt::Display for Data {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Utf8(text) => write!(f, "{text}"),
-            Self::Binary(data) => {
-                for byte in data {
-                    write!(f, "{byte:02x}")?;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
 impl fmt::Display for CloudFormationParams {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -231,296 +152,4 @@ impl fmt::Display for CloudFormationParams {
             self.key_arn.as_ref().map_or("None", |k| k)
         )
     }
-}
-
-impl Vault {
-    pub async fn new(
-        vault_stack: Option<&str>,
-        region_opt: Option<&str>,
-    ) -> Result<Self, VaultError> {
-        let config = aws_config::from_env()
-            .region(get_region_provider(region_opt))
-            .load()
-            .await;
-
-        let region = config
-            .region()
-            .map(ToOwned::to_owned)
-            .ok_or_else(|| VaultError::NoRegionError)?;
-
-        // Check env variables directly in case the library is not used through the CLI.
-        // These are also handled in the CLI, so they are documented in the CLI help.
-        let vault_stack_from_env = get_env_variable("VAULT_STACK");
-        let vault_bucket_from_env = get_env_variable("VAULT_BUCKET");
-        let vault_key_from_env = get_env_variable("VAULT_KEY");
-
-        let cloudformation_params =
-            if let (Some(bucket), Some(key)) = (vault_bucket_from_env, vault_key_from_env) {
-                CloudFormationParams::new(bucket, Some(key))
-            } else {
-                let stack_name = vault_stack_from_env
-                    .as_deref()
-                    .or(vault_stack)
-                    .unwrap_or("vault");
-
-                CloudFormationParams::get_from_stack(&config, stack_name).await?
-            };
-
-        Ok(Self {
-            region,
-            cloudformation_params,
-            s3: S3Client::new(&config),
-            kms: KmsClient::new(&config),
-        })
-    }
-
-    pub async fn from_cli_params(
-        bucket: &str,
-        key_arn: Option<&str>,
-        region_opt: Option<&str>,
-    ) -> Result<Self, VaultError> {
-        Self::from_params(CloudFormationParams::from(bucket, key_arn), region_opt).await
-    }
-
-    pub async fn from_params(
-        cloudformation_params: CloudFormationParams,
-        region_opt: Option<&str>,
-    ) -> Result<Self, VaultError> {
-        let config = aws_config::from_env()
-            .region(get_region_provider(region_opt))
-            .load()
-            .await;
-        Ok(Self {
-            region: config.region().ok_or(VaultError::NoRegionError)?.to_owned(),
-            cloudformation_params,
-            s3: S3Client::new(&config),
-            kms: KmsClient::new(&config),
-        })
-    }
-
-    /// Get all available secrets
-    pub async fn all(&self) -> Result<Vec<String>, VaultError> {
-        let output = self
-            .s3
-            .list_objects_v2()
-            .bucket(&self.cloudformation_params.bucket_name)
-            .send()
-            .await?;
-        Ok(output
-            .contents()
-            .iter()
-            .filter_map(|object| -> Option<String> {
-                object.key().and_then(|key| {
-                    if key.ends_with(".aesgcm.encrypted") {
-                        key.strip_suffix(".aesgcm.encrypted")
-                            .map(std::borrow::ToOwned::to_owned)
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect::<Vec<_>>())
-    }
-
-    /// Get `CloudFormation` stack information
-    #[must_use]
-    pub fn stack_info(&self) -> CloudFormationParams {
-        self.cloudformation_params.clone()
-    }
-
-    /// Encrypt data
-    async fn encrypt(&self, data: &[u8]) -> Result<EncryptObject, VaultError> {
-        let key_dict = self
-            .kms
-            .generate_data_key()
-            .key_id(
-                self.cloudformation_params
-                    .key_arn
-                    .clone()
-                    .ok_or(VaultError::KeyARNMissingError)?,
-            )
-            .key_spec(DataKeySpec::Aes256)
-            .send()
-            .await?;
-
-        let plaintext = key_dict
-            .plaintext()
-            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)?;
-
-        let aesgcm_cipher: AesGcm<Aes256, cipher::typenum::U12> =
-            AesGcm::new_from_slice(plaintext.as_ref())?;
-        let nonce = Self::create_random_nonce();
-        let nonce = Nonce::from_slice(nonce.as_slice());
-        let meta = Meta::new("AESGCM", nonce).to_json()?;
-        let aes_gcm_ciphertext = aesgcm_cipher
-            .encrypt(
-                nonce,
-                Payload {
-                    msg: data,
-                    aad: meta.as_bytes(),
-                },
-            )
-            .map_err(|_| VaultError::CiphertextEncryptionError)?;
-
-        let data_key = key_dict
-            .ciphertext_blob()
-            .ok_or(VaultError::CiphertextEncryptionError)?
-            .to_owned()
-            .into_inner();
-
-        Ok(EncryptObject {
-            data_key,
-            aes_gcm_ciphertext,
-            meta,
-        })
-    }
-
-    /// Get S3 Object data for given key as a vec of bytes
-    async fn get_s3_object(&self, key: String) -> Result<Vec<u8>, VaultError> {
-        self.s3
-            .get_object()
-            .bucket(self.cloudformation_params.bucket_name.clone())
-            .key(&key)
-            .send()
-            .await?
-            .body
-            .collect()
-            .await
-            .map_err(|_| VaultError::S3GetObjectBodyError)
-            .map(aws_sdk_s3::primitives::AggregatedBytes::to_vec)
-    }
-
-    /// Get decrypted data
-    async fn direct_decrypt(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, VaultError> {
-        self.kms
-            .decrypt()
-            .ciphertext_blob(Blob::new(encrypted_data))
-            .send()
-            .await?
-            .plaintext()
-            .map(|blob| blob.to_owned().into_inner())
-            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)
-    }
-
-    /// Send PUT request with the given byte data
-    async fn put_s3_object(
-        &self,
-        body: ByteStream,
-        key: String,
-    ) -> Result<PutObjectOutput, VaultError> {
-        Ok(self
-            .s3
-            .put_object()
-            .bucket(&self.cloudformation_params.bucket_name)
-            .key(key)
-            .acl(aws_sdk_s3::types::ObjectCannedAcl::Private)
-            .body(body)
-            .send()
-            .await?)
-    }
-
-    /// Check if key already exists in bucket
-    // TODO: somewhat bad implementation, can fail for other reasons as well?
-    pub async fn exists(&self, name: &str) -> Result<bool, VaultError> {
-        if let Err(e) = self
-            .s3
-            .head_object()
-            .bucket(self.cloudformation_params.bucket_name.clone())
-            .key(format!("{name}.key"))
-            .send()
-            .await
-        {
-            let service_error = e.into_service_error();
-            if service_error.is_not_found() {
-                Ok(false)
-            } else {
-                Err(VaultError::S3HeadObjectError(service_error))
-            }
-        } else {
-            Ok(true)
-        }
-    }
-
-    /// Store encrypted data in S3
-    pub async fn store(&self, name: &str, data: &[u8]) -> Result<(), VaultError> {
-        let encrypted = self.encrypt(data).await?;
-        let first = self.put_s3_object(
-            ByteStream::from(encrypted.aes_gcm_ciphertext),
-            format!("{name}.aesgcm.encrypted"),
-        );
-        let second =
-            self.put_s3_object(ByteStream::from(encrypted.data_key), format!("{name}.key"));
-        let third = self.put_s3_object(
-            ByteStream::from(encrypted.meta.into_bytes()),
-            format!("{name}.meta"),
-        );
-        try_join!(first, second, third)?;
-
-        Ok(())
-    }
-
-    /// Delete data in S3 for given key
-    pub async fn delete(&self, name: &str) -> Result<(), VaultError> {
-        if !self.exists(name).await? {
-            return Err(VaultError::S3DeleteObjectKeyMissingError);
-        }
-
-        let keys = S3DataKeys::new(name);
-        let identifiers = keys.to_object_identifiers()?;
-        self.s3
-            .delete_objects()
-            .bucket(&self.cloudformation_params.bucket_name)
-            .delete(Delete::builder().set_objects(Some(identifiers)).build()?)
-            .send()
-            .await?;
-
-        Ok(())
-    }
-
-    /// Return value for the given key name.
-    /// If the data is valid UTF-8, it will be returned as a string.
-    /// Otherwise, the raw bytes will be returned.
-    pub async fn lookup(&self, name: &str) -> Result<Data, VaultError> {
-        let keys = S3DataKeys::new(name);
-        let data_key = self.get_s3_object(keys.key);
-        let cipher_text = self.get_s3_object(keys.cipher);
-        let meta_add = self.get_s3_object(keys.meta);
-        let (data_key, cipher_text, meta_add) = try_join!(data_key, cipher_text, meta_add)?;
-        let meta: Meta = serde_json::from_slice(&meta_add)?;
-        let cipher: AesGcm<Aes256, cipher::typenum::U12> =
-            AesGcm::new_from_slice(self.direct_decrypt(&data_key).await?.as_slice())?;
-        let nonce = base64::engine::general_purpose::STANDARD.decode(meta.nonce)?;
-        let nonce = Nonce::from_slice(nonce.as_slice());
-        let res = cipher
-            .decrypt(
-                nonce,
-                Payload {
-                    msg: &cipher_text,
-                    aad: &meta_add,
-                },
-            )
-            .map_err(|_| VaultError::NonceDecryptError)?;
-
-        match String::from_utf8(res) {
-            Ok(valid_string) => Ok(Data::Utf8(valid_string)),
-            Err(from_utf8_error) => Ok(Data::Binary(from_utf8_error.into_bytes())),
-        }
-    }
-
-    fn create_random_nonce() -> [u8; 12] {
-        let mut nonce: [u8; 12] = [0; 12];
-        let mut rng = rand::thread_rng();
-        rng.fill(nonce.as_mut_slice());
-        nonce
-    }
-}
-
-fn get_region_provider(region_opt: Option<&str>) -> RegionProviderChain {
-    RegionProviderChain::first_try(region_opt.map(|r| Region::new(r.to_owned())))
-        .or_default_provider()
-}
-
-/// Return possible env variable value as Option
-fn get_env_variable(name: &str) -> Option<String> {
-    env::var(name).ok()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,11 +6,9 @@ mod vault;
 pub use crate::value::Value;
 pub use crate::vault::Vault;
 
-use std::env;
 use std::fmt;
 
-use aws_config::meta::region::RegionProviderChain;
-use aws_config::{Region, SdkConfig};
+use aws_config::SdkConfig;
 use aws_sdk_cloudformation::types::Output;
 use aws_sdk_cloudformation::Client as CloudFormationClient;
 use aws_sdk_s3::types::ObjectIdentifier;
@@ -43,16 +41,6 @@ struct S3DataKeys {
     key: String,
     cipher: String,
     meta: String,
-}
-
-/// Get AWS region from optional argument or fallback to default
-fn get_region_provider(region: Option<&str>) -> RegionProviderChain {
-    RegionProviderChain::first_try(region.map(|r| Region::new(r.to_owned()))).or_default_provider()
-}
-
-/// Return possible env variable value as Option
-fn get_env_variable(name: &str) -> Option<String> {
-    env::var(name).ok()
 }
 
 impl CloudFormationParams {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -109,6 +109,10 @@ impl Meta {
         }
     }
 
+    pub fn aesgcm(nonce: &[u8]) -> Self {
+        Self::new("AESGCM", nonce)
+    }
+
     /// Serialize Meta to JSON string.
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string(&self)

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,14 +1,126 @@
 mod cli;
 
 use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
 use colored::Colorize;
+
 use nitor_vault::Vault;
 
-use crate::cli::{Args, Command};
+#[allow(clippy::doc_markdown)]
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Nitor Vault, see https://github.com/nitorcreations/vault for usage examples",
+    arg_required_else_help = true
+)]
+pub struct Args {
+    /// Override the bucket name
+    #[arg(short, long, env = "VAULT_BUCKET")]
+    pub bucket: Option<String>,
+
+    /// Override the KMS key arn for storing or looking up
+    #[arg(short, long, env = "VAULT_KEY")]
+    pub key_arn: Option<String>,
+
+    /// Specify AWS region for the bucket
+    #[arg(short, long, env = "AWS_REGION")]
+    pub region: Option<String>,
+
+    /// Optional CloudFormation stack to lookup key and bucket
+    #[arg(long, env)]
+    pub vault_stack: Option<String>,
+
+    /// Available subcommands
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[allow(clippy::doc_markdown)]
+#[derive(Subcommand)]
+pub enum Command {
+    /// List available secrets
+    #[command(short_flag('a'), long_flag("all"), alias("a"))]
+    All {},
+
+    /// Delete an existing key from the store
+    #[command(short_flag('d'), long_flag("delete"))]
+    Delete { key: String },
+
+    /// Describe CloudFormation stack parameters for current configuration.
+    // This value is useful for Lambdas as you can load the CloudFormation parameters from env.
+    #[command(long_flag("describe"))]
+    Describe {},
+
+    /// Check if a key exists
+    #[command(short_flag('e'), long_flag("exists"), alias("e"))]
+    Exists { key: String },
+
+    /// Print region and stack information
+    #[command(short_flag('i'), long_flag("info"), alias("i"))]
+    Info {},
+
+    /// Output secret value for given key
+    #[command(short_flag('l'), long_flag("lookup"), alias("l"))]
+    Lookup {
+        /// Key name to lookup
+        key: String,
+
+        /// Optional output file
+        #[arg(short, long, value_name = "filepath")]
+        outfile: Option<String>,
+    },
+
+    /// Store a new key-value pair
+    #[command(
+        short_flag('s'),
+        long_flag("store"),
+        alias("s"),
+        long_about = "Store a new key-value pair in the vault.\n\
+                      You can provide the key and value directly, or specify a file to store.\n\n\
+                      Usage examples:\n\
+                      - Store a value: `vault store mykey \"some value\"`\n\
+                      - Store a value from args: `vault store mykey --value \"some value\"`\n\
+                      - Store from a file: `vault store mykey --file path/to/file.txt`\n\
+                      - Store from a file with filename as key: `vault store --file path/to/file.txt`\n\
+                      - Store from stdin: `echo \"some data\" | vault store mykey --value -`\n\
+                      - Store from stdin: `cat file.zip | vault store mykey --file -`"
+    )]
+    Store {
+        /// Key name
+        key: Option<String>,
+
+        /// Value to store
+        value: Option<String>,
+
+        /// Overwrite existing key
+        #[arg(short = 'w', long)]
+        overwrite: bool,
+
+        /// Value to store, use '-' for stdin
+        #[arg(
+            short,
+            long = "value",
+            value_name = "value",
+            conflicts_with_all = vec!["value", "file"]
+        )]
+        value_argument: Option<String>,
+
+        /// File to store, use '-' for stdin
+        #[arg(
+            short,
+            long,
+            value_name = "filepath",
+            conflicts_with_all = vec!["value", "value_opt"]
+        )]
+        file: Option<String>,
+    },
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args: Args = cli::parse_args();
+    let args = Args::parse();
 
     // Bucket and key were either given as args or found in env variables
     let vault = if let (Some(bucket), key_arn) = (args.bucket.as_deref(), args.key_arn.as_deref()) {
@@ -26,10 +138,11 @@ async fn main() -> Result<()> {
     // Handle subcommands
     if let Some(command) = args.command {
         return match command {
+            Command::All {} => cli::list_all_keys(&vault).await,
             Command::Delete { key } => cli::delete(&vault, &key).await,
             Command::Describe {} => Ok(println!("{}", vault.stack_info())),
             Command::Exists { key } => cli::exists(&vault, &key).await,
-            Command::All {} => cli::list_all(&vault).await,
+            Command::Info {} => Ok(println!("{vault}")),
             Command::Lookup { key, outfile } => cli::lookup(&vault, &key, outfile).await,
             Command::Store {
                 key,
@@ -38,7 +151,6 @@ async fn main() -> Result<()> {
                 file,
                 value_argument,
             } => cli::store(&vault, key, value, file, value_argument, overwrite).await,
-            Command::Info {} => Ok(println!("{vault}")),
         };
     }
     Ok(())

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -1,0 +1,69 @@
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::{fmt, io};
+
+#[derive(Debug, Clone)]
+/// Vault supports storing arbitrary data that might not be valid UTF-8.
+/// Handle values as either UTF-8 or binary.
+pub enum Value {
+    Utf8(String),
+    Binary(Vec<u8>),
+}
+
+impl Value {
+    /// Returns the data as a byte slice (`&[u8]`)
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Utf8(ref string) => string.as_bytes(),
+            Self::Binary(ref bytes) => bytes,
+        }
+    }
+
+    /// Outputs the data directly to stdout.
+    /// String data is printed.
+    /// Binary data is outputted raw.
+    pub fn output_to_stdout(&self) -> io::Result<()> {
+        match self {
+            Self::Utf8(ref string) => {
+                print!("{string}");
+                Ok(())
+            }
+            Self::Binary(ref bytes) => {
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                handle.write_all(bytes)?;
+                handle.flush()
+            }
+        }
+    }
+
+    /// Outputs the data to the specified file path.
+    pub fn output_to_file(&self, path: &Path) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        match self {
+            Self::Utf8(ref string) => {
+                writer.write_all(string.as_bytes())?;
+            }
+            Self::Binary(ref bytes) => {
+                writer.write_all(bytes)?;
+            }
+        }
+        writer.flush()
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Utf8(text) => write!(f, "{text}"),
+            Self::Binary(data) => {
+                for byte in data {
+                    write!(f, "{byte:02x}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -148,7 +148,7 @@ impl Vault {
             AesGcm::new_from_slice(plaintext.as_ref())?;
         let nonce = Self::create_random_nonce();
         let nonce = Nonce::from_slice(nonce.as_slice());
-        let meta = Meta::new("AESGCM", nonce).to_json()?;
+        let meta = Meta::aesgcm(nonce).to_json()?;
         let aes_gcm_ciphertext = aesgcm_cipher
             .encrypt(
                 nonce,

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -1,0 +1,321 @@
+use std::fmt;
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::aes::{cipher, Aes256};
+use aes_gcm::{AesGcm, KeyInit, Nonce};
+use aws_config::Region;
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::DataKeySpec;
+use aws_sdk_kms::Client as KmsClient;
+use aws_sdk_s3::operation::put_object::PutObjectOutput;
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::Delete;
+use aws_sdk_s3::Client as S3Client;
+use base64::Engine;
+use rand::Rng;
+use tokio::try_join;
+
+use crate::errors::VaultError;
+use crate::value::Value;
+use crate::{CloudFormationParams, EncryptObject, Meta, S3DataKeys};
+
+#[derive(Debug)]
+pub struct Vault {
+    /// AWS region to use with Vault.
+    /// Will fall back to default provider if nothing is specified.
+    region: Region,
+    cloudformation_params: CloudFormationParams,
+    s3: S3Client,
+    kms: KmsClient,
+}
+
+impl Vault {
+    pub async fn new(
+        vault_stack: Option<&str>,
+        region_opt: Option<&str>,
+    ) -> Result<Self, VaultError> {
+        let config = aws_config::from_env()
+            .region(crate::get_region_provider(region_opt))
+            .load()
+            .await;
+
+        let region = config
+            .region()
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| VaultError::NoRegionError)?;
+
+        // Check env variables directly in case the library is not used through the CLI.
+        // These are also handled in the CLI, so they are documented in the CLI help.
+        let vault_stack_from_env = crate::get_env_variable("VAULT_STACK");
+        let vault_bucket_from_env = crate::get_env_variable("VAULT_BUCKET");
+        let vault_key_from_env = crate::get_env_variable("VAULT_KEY");
+
+        let cloudformation_params =
+            if let (Some(bucket), Some(key)) = (vault_bucket_from_env, vault_key_from_env) {
+                CloudFormationParams::new(bucket, Some(key))
+            } else {
+                let stack_name = vault_stack_from_env
+                    .as_deref()
+                    .or(vault_stack)
+                    .unwrap_or("vault");
+
+                CloudFormationParams::get_from_stack(&config, stack_name).await?
+            };
+
+        Ok(Self {
+            region,
+            cloudformation_params,
+            s3: S3Client::new(&config),
+            kms: KmsClient::new(&config),
+        })
+    }
+
+    pub async fn from_cli_params(
+        bucket: &str,
+        key_arn: Option<&str>,
+        region_opt: Option<&str>,
+    ) -> Result<Self, VaultError> {
+        Self::from_params(CloudFormationParams::from(bucket, key_arn), region_opt).await
+    }
+
+    pub async fn from_params(
+        cloudformation_params: CloudFormationParams,
+        region_opt: Option<&str>,
+    ) -> Result<Self, VaultError> {
+        let config = aws_config::from_env()
+            .region(crate::get_region_provider(region_opt))
+            .load()
+            .await;
+        Ok(Self {
+            region: config.region().ok_or(VaultError::NoRegionError)?.to_owned(),
+            cloudformation_params,
+            s3: S3Client::new(&config),
+            kms: KmsClient::new(&config),
+        })
+    }
+
+    /// Get all available secrets
+    pub async fn all(&self) -> Result<Vec<String>, VaultError> {
+        let output = self
+            .s3
+            .list_objects_v2()
+            .bucket(&self.cloudformation_params.bucket_name)
+            .send()
+            .await?;
+
+        Ok(output
+            .contents()
+            .iter()
+            .filter_map(|object| -> Option<String> {
+                object.key().and_then(|key| {
+                    if key.ends_with(".aesgcm.encrypted") {
+                        key.strip_suffix(".aesgcm.encrypted")
+                            .map(std::borrow::ToOwned::to_owned)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Get `CloudFormation` stack information
+    #[must_use]
+    pub fn stack_info(&self) -> CloudFormationParams {
+        self.cloudformation_params.clone()
+    }
+
+    /// Encrypt data
+    async fn encrypt(&self, data: &[u8]) -> Result<EncryptObject, VaultError> {
+        let key_dict = self
+            .kms
+            .generate_data_key()
+            .key_id(
+                self.cloudformation_params
+                    .key_arn
+                    .clone()
+                    .ok_or(VaultError::KeyARNMissingError)?,
+            )
+            .key_spec(DataKeySpec::Aes256)
+            .send()
+            .await?;
+
+        let plaintext = key_dict
+            .plaintext()
+            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)?;
+
+        let aesgcm_cipher: AesGcm<Aes256, cipher::typenum::U12> =
+            AesGcm::new_from_slice(plaintext.as_ref())?;
+        let nonce = Self::create_random_nonce();
+        let nonce = Nonce::from_slice(nonce.as_slice());
+        let meta = Meta::new("AESGCM", nonce).to_json()?;
+        let aes_gcm_ciphertext = aesgcm_cipher
+            .encrypt(
+                nonce,
+                Payload {
+                    msg: data,
+                    aad: meta.as_bytes(),
+                },
+            )
+            .map_err(|_| VaultError::CiphertextEncryptionError)?;
+
+        let data_key = key_dict
+            .ciphertext_blob()
+            .ok_or(VaultError::CiphertextEncryptionError)?
+            .to_owned()
+            .into_inner();
+
+        Ok(EncryptObject {
+            data_key,
+            aes_gcm_ciphertext,
+            meta,
+        })
+    }
+
+    /// Get S3 Object data for given key as a vec of bytes
+    async fn get_s3_object(&self, key: String) -> Result<Vec<u8>, VaultError> {
+        self.s3
+            .get_object()
+            .bucket(self.cloudformation_params.bucket_name.clone())
+            .key(&key)
+            .send()
+            .await?
+            .body
+            .collect()
+            .await
+            .map_err(|_| VaultError::S3GetObjectBodyError)
+            .map(aws_sdk_s3::primitives::AggregatedBytes::to_vec)
+    }
+
+    /// Get decrypted data
+    async fn direct_decrypt(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, VaultError> {
+        self.kms
+            .decrypt()
+            .ciphertext_blob(Blob::new(encrypted_data))
+            .send()
+            .await?
+            .plaintext()
+            .map(|blob| blob.to_owned().into_inner())
+            .ok_or(VaultError::KMSDataKeyPlainTextMissingError)
+    }
+
+    /// Send PUT request with the given byte data
+    async fn put_s3_object(
+        &self,
+        body: ByteStream,
+        key: String,
+    ) -> Result<PutObjectOutput, VaultError> {
+        Ok(self
+            .s3
+            .put_object()
+            .bucket(&self.cloudformation_params.bucket_name)
+            .key(key)
+            .acl(aws_sdk_s3::types::ObjectCannedAcl::Private)
+            .body(body)
+            .send()
+            .await?)
+    }
+
+    /// Check if key already exists in bucket
+    pub async fn exists(&self, name: &str) -> Result<bool, VaultError> {
+        match self
+            .s3
+            .head_object()
+            .bucket(self.cloudformation_params.bucket_name.clone())
+            .key(format!("{name}.key"))
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let service_error = e.into_service_error();
+                if service_error.is_not_found() {
+                    // The object does not exist
+                    Ok(false)
+                } else {
+                    // Propagate other errors like networking or permissions
+                    Err(VaultError::S3HeadObjectError(service_error))
+                }
+            }
+        }
+    }
+
+    /// Store encrypted data in S3
+    pub async fn store(&self, name: &str, data: &[u8]) -> Result<(), VaultError> {
+        let encrypted = self.encrypt(data).await?;
+        let first = self.put_s3_object(
+            ByteStream::from(encrypted.aes_gcm_ciphertext),
+            format!("{name}.aesgcm.encrypted"),
+        );
+        let second =
+            self.put_s3_object(ByteStream::from(encrypted.data_key), format!("{name}.key"));
+        let third = self.put_s3_object(
+            ByteStream::from(encrypted.meta.into_bytes()),
+            format!("{name}.meta"),
+        );
+        try_join!(first, second, third)?;
+
+        Ok(())
+    }
+
+    /// Delete data in S3 for given key
+    pub async fn delete(&self, name: &str) -> Result<(), VaultError> {
+        if !self.exists(name).await? {
+            return Err(VaultError::S3DeleteObjectKeyMissingError);
+        }
+
+        let keys = S3DataKeys::new(name);
+        let identifiers = keys.to_object_identifiers()?;
+        self.s3
+            .delete_objects()
+            .bucket(&self.cloudformation_params.bucket_name)
+            .delete(Delete::builder().set_objects(Some(identifiers)).build()?)
+            .send()
+            .await?;
+
+        Ok(())
+    }
+
+    /// Return value for the given key name.
+    /// If the data is valid UTF-8, it will be returned as a string.
+    /// Otherwise, the raw bytes will be returned.
+    pub async fn lookup(&self, name: &str) -> Result<Value, VaultError> {
+        let keys = S3DataKeys::new(name);
+        let data_key = self.get_s3_object(keys.key);
+        let cipher_text = self.get_s3_object(keys.cipher);
+        let meta_add = self.get_s3_object(keys.meta);
+        let (data_key, cipher_text, meta_add) = try_join!(data_key, cipher_text, meta_add)?;
+        let meta: Meta = serde_json::from_slice(&meta_add)?;
+        let cipher: AesGcm<Aes256, cipher::typenum::U12> =
+            AesGcm::new_from_slice(self.direct_decrypt(&data_key).await?.as_slice())?;
+        let nonce = base64::engine::general_purpose::STANDARD.decode(meta.nonce)?;
+        let nonce = Nonce::from_slice(nonce.as_slice());
+        let res = cipher
+            .decrypt(
+                nonce,
+                Payload {
+                    msg: &cipher_text,
+                    aad: &meta_add,
+                },
+            )
+            .map_err(|_| VaultError::NonceDecryptError)?;
+
+        match String::from_utf8(res) {
+            Ok(valid_string) => Ok(Value::Utf8(valid_string)),
+            Err(from_utf8_error) => Ok(Value::Binary(from_utf8_error.into_bytes())),
+        }
+    }
+
+    fn create_random_nonce() -> [u8; 12] {
+        let mut nonce: [u8; 12] = [0; 12];
+        let mut rng = rand::thread_rng();
+        rng.fill(nonce.as_mut_slice());
+        nonce
+    }
+}
+
+impl fmt::Display for Vault {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "region: {}\n{}", self.region, self.cloudformation_params)
+    }
+}


### PR DESCRIPTION
- Rename Data to Value
- Move Vault and related impls to vault.rs
- Move Value and related impls to value.rs
- Move cli arguments to main, I prefer to see the available args etc directly in main

Public API does not change, can import lib using `nitor_vault::Vault` like before