### PR TITLE
Python vault refactoring and code organization

### DIFF
--- a/python/n_vault/__init__.py
+++ b/python/n_vault/__init__.py
@@ -36,5 +36,4 @@ def stop_cov(signum, frame):
         sys.exit(0)
 
 
-# flake8: noqa
-from n_vault.vault import Vault
+from n_vault.vault import Vault as Vault  # noqa: E402

--- a/python/n_vault/template.py
+++ b/python/n_vault/template.py
@@ -1,6 +1,7 @@
-# flake8: noqa: E501
 VAULT_STACK_VERSION = 24
-TEMPLATE_STRING = f"""{{
+
+TEMPLATE_STRING = f"""
+{{
   "Parameters": {{
     "paramBucketName": {{
       "Default": "nitor-core-vault",
@@ -508,4 +509,4 @@ TEMPLATE_STRING = f"""{{
       }}
     }}
   }}
-}}"""
+}}"""  # noqa: E501


### PR DESCRIPTION
Making a separate PR for my Python changes made when implementing the init and update for Rust.

- In Vault.py, put private functions and methods after public. Change helper functions to static methods inside Vault class.
- Encapsulate `STATIC_IV` as a static class member since it is not used outside the Vault class.
- Make `to_str` public since it is used in the cli
- Streamline vault initialization for `init` case and others