### PR TITLE
Rust: Move vault update prints from library to cli

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitor-vault"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility."
 license = "Apache-2.0"

--- a/rust/src/cloudformation.rs
+++ b/rust/src/cloudformation.rs
@@ -93,7 +93,7 @@ impl fmt::Display for CloudFormationStackData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "status: {}\nbucket: {}\nkey ARN: {}\nversion: {}{}",
+            "status: {}\nbucket: {}\nkey: {}\nversion: {}{}",
             self.status
                 .as_ref()
                 .map_or("None".to_string(), std::string::ToString::to_string),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,6 +32,19 @@ pub enum CreateStackResult {
 }
 
 #[derive(Debug, Clone)]
+/// Result data for updating the vault stack.
+pub enum UpdateStackResult {
+    /// Vault stack is up to date.
+    UpToDate { data: CloudFormationStackData },
+    /// Vault stack was updated.
+    Update {
+        stack_id: String,
+        previous_version: u32,
+        new_version: u32,
+    },
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct EncryptObject {
     data_key: Vec<u8>,
     aes_gcm_ciphertext: Vec<u8>,

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -99,6 +99,9 @@ impl Vault {
     /// Initialize new Vault stack.
     /// This will create all required resources in AWS,
     /// after which the Vault can be used to store and lookup values.
+    ///
+    /// Returns a `CreateStackResult` with relevant data whether a new vault stack was initialized,
+    /// or it already exists.
     pub async fn init(
         vault_stack: Option<String>,
         region: Option<String>,
@@ -176,6 +179,10 @@ impl Vault {
         })
     }
 
+    /// Update the vault Cloudformation stack with the current template.
+    ///
+    /// Returns an `UpdateStackResult` enum that indicates if the vault was updated,
+    /// or is already up to date.
     pub async fn update_stack(&self) -> Result<UpdateStackResult, VaultError> {
         let stack_name = &self.cloudformation_params.stack_name;
         let stack_data = cloudformation::get_stack_data(&self.cf, stack_name).await?;
@@ -340,6 +347,7 @@ impl Vault {
         }
     }
 
+    /// Return AWS SDK config with optional region name to use.
     pub async fn get_aws_config(region: Option<String>) -> SdkConfig {
         aws_config::from_env()
             .region(get_region_provider(region))


### PR DESCRIPTION
Same fixes as for the init that I did not realize to do previously:

Separate CLI stuff from vault library, move prints to CLI side.