### PR TITLE
rust: implement direct encrypt and decrypt to match python

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitor-vault"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility."
 license = "Apache-2.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -22,18 +22,20 @@ Encrypted AWS key-value storage utility.
 Usage: vault [OPTIONS] [COMMAND]
 
 Commands:
-  all, -a, --all        List available secrets
-  delete, -d, --delete  Delete an existing key from the store
-  describe, --describe  Describe CloudFormation stack parameters for current configuration
-  exists, -e, --exists  Check if a key exists
-  info, --info          Print vault information
-  id, --id              Print AWS user account information
-  status, --status      Print vault stack information
-  init, -i, --init      Initialize a new KMS key and S3 bucket
-  update, -u, --update  Update the vault CloudFormation stack
-  lookup, -l, --lookup  Output secret value for given key
-  store, -s, --store    Store a new key-value pair
-  help                  Print this message or the help of the given subcommand(s)
+  all, -a, --all          List available secrets
+  delete, -d, --delete    Delete an existing key from the store
+  describe, --describe    Describe CloudFormation stack parameters for current configuration
+  decrypt, -y, --decrypt  Directly decrypt given value
+  encrypt, -e, --encrypt  Directly encrypt given value
+  exists, --exists        Check if a key exists
+  info, --info            Print vault information
+  id, --id                Print AWS user account information
+  status, --status        Print vault stack information
+  init, -i, --init        Initialize a new KMS key and S3 bucket
+  update, -u, --update    Update the vault CloudFormation stack
+  lookup, -l, --lookup    Output secret value for given key
+  store, -s, --store      Store a new key-value pair
+  help                    Print this message or the help of the given subcommand(s)
 
 Options:
   -b, --bucket <BUCKET>     Override the bucket name [env: VAULT_BUCKET=]

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -176,6 +176,46 @@ pub async fn exists(vault: &Vault, key: &str) -> Result<()> {
         })
 }
 
+/// Directly encrypt given value with KMS.
+pub async fn encrypt(
+    vault: &Vault,
+    value_positional: Option<String>,
+    file: Option<String>,
+    value_argument: Option<String>,
+    outfile: Option<String>,
+) -> Result<()> {
+    let data = read_value(value_positional, value_argument, file)?;
+    let bytes = vault.direct_encrypt(data.as_bytes()).await?;
+    let value = Value::new(bytes);
+
+    match resolve_output_file_path(outfile)? {
+        Some(path) => value.output_to_file(&path)?,
+        None => value.output_to_stdout()?,
+    };
+
+    Ok(())
+}
+
+/// Directly decrypt given value with KMS.
+pub async fn decrypt(
+    vault: &Vault,
+    value_positional: Option<String>,
+    file: Option<String>,
+    value_argument: Option<String>,
+    outfile: Option<String>,
+) -> Result<()> {
+    let data = read_value(value_positional, value_argument, file)?;
+    let bytes = vault.direct_decrypt(data.as_bytes()).await?;
+    let value = Value::new(bytes);
+
+    match resolve_output_file_path(outfile)? {
+        Some(path) => value.output_to_file(&path)?,
+        None => value.output_to_stdout()?,
+    };
+
+    Ok(())
+}
+
 /// Print the information from AWS STS "get caller identity" call.
 pub async fn print_aws_account(region: Option<String>) -> Result<()> {
     let config = Vault::get_aws_config(region).await;

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -7,6 +7,7 @@ use aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError;
 use aws_sdk_cloudformation::operation::update_stack::UpdateStackError;
 use aws_sdk_cloudformation::Error as cloudformationError;
 use aws_sdk_kms::operation::decrypt::DecryptError;
+use aws_sdk_kms::operation::encrypt::EncryptError;
 use aws_sdk_kms::operation::generate_data_key::GenerateDataKeyError;
 use aws_sdk_s3::error::BuildError;
 use aws_sdk_s3::operation::delete_object::DeleteObjectError;
@@ -28,15 +29,17 @@ pub enum VaultError {
     #[error("Failed to get bucket name from stack")]
     BucketNameMissingError,
     #[error("No KEY_ARN provided, can't encrypt")]
-    KeyARNMissingError,
+    KeyArnMissingError,
     #[error("Failed to generate KMS Data key")]
-    KMSGenerateDataKeyError(#[from] SdkError<GenerateDataKeyError>),
+    KmsGenerateDataKeyError(#[from] SdkError<GenerateDataKeyError>),
     #[error("Failed to decrypt Ciphertext with KMS")]
-    KMSDecryptError(#[from] SdkError<DecryptError>),
+    KmsDecryptError(#[from] SdkError<DecryptError>),
+    #[error("Failed to encrypt data with KMS")]
+    KmsEncryptError(#[from] SdkError<EncryptError>),
     #[error("No Plaintext for generated data key")]
-    KMSDataKeyPlainTextMissingError,
+    KmsDataKeyPlainTextMissingError,
     #[error("No ciphertextBlob for generated data key")]
-    KMSDataKeyCiphertextBlobMissingError,
+    KmsDataKeyCiphertextBlobMissingError,
     #[error("Invalid length for encryption cipher")]
     InvalidNonceLengthError(#[from] aes_gcm::aes::cipher::InvalidLength),
     #[error("Invalid length for encryption cipher")]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -77,7 +77,7 @@ enum Command {
             short,
             long,
             value_name = "filepath",
-            conflicts_with_all = vec!["value", "value_opt"]
+            conflicts_with_all = vec!["value", "value_argument"]
         )]
         file: Option<String>,
 
@@ -106,7 +106,7 @@ enum Command {
             short,
             long,
             value_name = "filepath",
-            conflicts_with_all = vec!["value", "value_opt"]
+            conflicts_with_all = vec!["value", "value_argument"]
         )]
         file: Option<String>,
 
@@ -214,7 +214,7 @@ enum Command {
             short,
             long,
             value_name = "filepath",
-            conflicts_with_all = vec!["value", "value_opt"]
+            conflicts_with_all = vec!["value", "value_argument"]
         )]
         file: Option<String>,
 

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -14,11 +14,25 @@ pub enum Value {
 
 impl Value {
     #[must_use]
-    /// Create a `Value` from raw bytes.
+    /// Create a `Value` from owned raw bytes.
     ///
     /// This will check if the given bytes are valid UTF-8,
     /// and return the corresponding enum value.
-    pub fn new(bytes: &[u8]) -> Self {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        #[allow(clippy::option_if_let_else)]
+        // ^using `map_or` would require cloning buffer
+        match std::str::from_utf8(&bytes) {
+            Ok(valid_utf8) => Self::Utf8(valid_utf8.to_string()),
+            Err(_) => Self::Binary(bytes),
+        }
+    }
+
+    #[must_use]
+    /// Create a `Value` from raw bytes slice.
+    ///
+    /// This will check if the given bytes are valid UTF-8,
+    /// and return the corresponding enum value.
+    pub fn from(bytes: &[u8]) -> Self {
         std::str::from_utf8(bytes).map_or_else(
             |_| Self::Binary(Vec::from(bytes)),
             |valid_utf8| Self::Utf8(valid_utf8.to_string()),


### PR DESCRIPTION
Implement `decrypt` and `encrypt` cli commands

```console
➜  rust git:(rust/direct-encrypt) ./vault encrypt test
00Q0L36\`He.0U}]b0`	*H
             -	�Tri��-Ѣ
                        Co"�Y*2�(��%                          
                                                                                                                                                
➜  rust git:(rust/direct-encrypt) ✗ ./vault encrypt test -o test.txt

➜  rust git:(rust/direct-encrypt) ✗ ./vault decrypt -f test.txt
test%
```