### PR TITLE
rust: output encrypted binary data always as base64

### DIFF
--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -189,8 +189,8 @@ pub async fn encrypt(
     let value = Value::new(bytes);
 
     match resolve_output_file_path(outfile)? {
-        Some(path) => value.output_to_file(&path)?,
-        None => value.output_to_stdout()?,
+        Some(path) => value.output_base64_to_file(&path)?,
+        None => value.output_base64_to_stdout()?,
     };
 
     Ok(())
@@ -352,7 +352,7 @@ fn read_value(
         if value == "-" {
             Value::from_stdin()?
         } else {
-            Value::Utf8(value)
+            Value::from_possibly_base64_encoded(value)
         }
     } else if let Some(path) = file {
         match path.as_str() {

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -91,7 +91,7 @@ impl Value {
         #[allow(clippy::option_if_let_else)]
         // ^using `map_or` would require cloning buffer
         match std::str::from_utf8(&bytes) {
-            Ok(valid_utf8) => Ok(Self::Utf8(valid_utf8.to_string())),
+            Ok(valid_utf8) => Ok(Self::Utf8(valid_utf8.trim().to_string())),
             Err(_) => Ok(Self::Binary(bytes)),
         }
     }


### PR DESCRIPTION
- Output direct encrypt result in base64 encoding
- Assume direct decrypt input is base64 encoded and try to decode

```console
➜  rust git:(rust/output-encrypted-base64) ./vault encrypt 'hello world!' -o out.txt

➜  rust git:(rust/output-encrypted-base64) ✗ cat out.txt
AQECAHgN/X7CNJJDsz+LAJDffTM2XHc91tXZLWmwH1WcrX1diAAAAGowaAYJKoZIhvcNAQcGoFswWQIBADBUBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDOR/Edj1mrkrfjS7NAIBEIAnZX7iCdgBgcsX8M6ligcaBT63I4hL8zmgDZBZNLn6Jc7+esdF+88f%            

➜  rust git:(rust/output-encrypted-base64) ✗ ./vault decrypt - < out.txt
hello world!%

➜  rust git:(rust/output-encrypted-base64) ✗ ./vault encrypt 'testing another string'
AQECAHgN/X7CNJJDsz+LAJDffTM2XHc91tXZLWmwH1WcrX1diAAAAHQwcgYJKoZIhvcNAQcGoGUwYwIBADBeBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLw1bzTmk5bcWslGBAIBEIAxJFGawnqdwRkpwLNnKuDJyBCw9KlQMT4YqeU6Hqary0dnkjWLvBMh2hbsDAp90oGrDw==%

➜  rust git:(rust/output-encrypted-base64) ✗ ./vault decrypt "AQECAHgN/X7CNJJDsz+LAJDffTM2XHc91tXZLWmwH1WcrX1diAAAAHQwcgYJKoZIhvcNAQcGoGUwYwIBADBeBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLw1bzTmk5bcWslGBAIBEIAxJFG
awnqdwRkpwLNnKuDJyBCw9KlQMT4YqeU6Hqary0dnkjWLvBMh2hbsDAp90oGrDw=="
testing another string%
```
