### PR TITLE
Rust: add profile CLI option and match closer to Python version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitor-vault"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "Encrypted AWS key-value storage utility"
 license = "Apache-2.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,36 +17,37 @@ By default, cargo puts the vault binary under `~/.cargo/bin/vault`.
 Check with `which -a vault` to see what vault version you have first in path.
 
 ```console
-Encrypted AWS key-value storage utility.
+Encrypted AWS key-value storage utility
 
 Usage: vault [OPTIONS] [COMMAND]
 
 Commands:
-  all, -a, --all            List available secrets
+  all, -a, --all            List available secrets [aliases: a, list, ls]
   completion, --completion  Generate shell completion
-  delete, -d, --delete      Delete an existing key from the store
-  describe, --describe      Describe CloudFormation stack parameters for current configuration
-  decrypt, -y, --decrypt    Directly decrypt given value
-  encrypt, -e, --encrypt    Directly encrypt given value
+  delete, -d, --delete      Delete an existing key from the store [aliases: d]
+  describe, --describe      Print CloudFormation stack parameters for current configuration
+  decrypt, -y, --decrypt    Directly decrypt given value [aliases: y]
+  encrypt, -e, --encrypt    Directly encrypt given value [aliases: e]
   exists, --exists          Check if a key exists
   info, --info              Print vault information
-  id, --id                  Print AWS user account information
+  id                        Print AWS user account information
   status, --status          Print vault stack information
-  init, -i, --init          Initialize a new KMS key and S3 bucket
-  update, -u, --update      Update the vault CloudFormation stack
-  lookup, -l, --lookup      Output secret value for given key
-  store, -s, --store        Store a new key-value pair
+  init, -i, --init          Initialize a new KMS key and S3 bucket [aliases: i]
+  update, -u, --update      Update the vault CloudFormation stack [aliases: u]
+  lookup, -l, --lookup      Output secret value for given key [aliases: l]
+  store, -s, --store        Store a new key-value pair [aliases: s]
   help                      Print this message or the help of the given subcommand(s)
 
 Options:
-  -b, --bucket <BUCKET>     Override the bucket name [env: VAULT_BUCKET=]
-  -k, --key-arn <ARN>       Override the KMS key ARN [env: VAULT_KEY=]
-  -p, --prefix <PREFIX>     Optional prefix for key name [env: VAULT_PREFIX=]
-  -r, --region <REGION>     Specify AWS region for the bucket [env: AWS_REGION=]
-      --vault-stack <NAME>  Specify CloudFormation stack name to use [env: VAULT_STACK=]
-  -q, --quiet               Suppress additional output and error messages
-  -h, --help                Print help (see more with '--help')
-  -V, --version             Print version
+  -b, --bucket <BUCKET>    Override the bucket name [env: VAULT_BUCKET=]
+  -k, --key-arn <ARN>      Override the KMS key ARN [env: VAULT_KEY=]
+  -p, --prefix <PREFIX>    Optional prefix for key name [env: VAULT_PREFIX=]
+  -r, --region <REGION>    Specify AWS region for the bucket [env: AWS_REGION=]
+      --vaultstack <NAME>  Specify CloudFormation stack name to use [env: VAULT_STACK=]
+      --profile <PROFILE>  Specify AWS profile to use [env: AWS_PROFILE=]
+  -q, --quiet              Suppress additional output and error messages
+  -h, --help               Print help (see more with '--help')
+  -V, --version            Print version
 ```
 
 ANSI color output can be disabled by setting the env variable `NO_COLOR=1`.

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -21,9 +21,10 @@ pub async fn init_vault_stack(
     stack_name: Option<String>,
     region: Option<String>,
     bucket: Option<String>,
+    profile: Option<String>,
     quiet: bool,
 ) -> Result<()> {
-    match Vault::init(stack_name, region, bucket).await? {
+    match Vault::init(stack_name, region, bucket, profile).await? {
         CreateStackResult::Exists { data } => {
             if !quiet {
                 println!("{}", "Vault stack already initialized:".bold());
@@ -241,8 +242,12 @@ pub async fn decrypt(
 }
 
 /// Print the information from AWS STS "get caller identity" call.
-pub async fn print_aws_account_id(region: Option<String>, quiet: bool) -> Result<()> {
-    let config = crate::get_aws_config(region).await;
+pub async fn print_aws_account_id(
+    region: Option<String>,
+    profile: Option<String>,
+    quiet: bool,
+) -> Result<()> {
+    let config = crate::get_aws_config(region, profile).await;
     let client = aws_sdk_sts::Client::new(&config);
     let result = client.get_caller_identity().send().await?;
     if !quiet {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -121,10 +121,20 @@ impl S3DataKeys {
 }
 
 #[inline]
+/// Return possible env variable value as Option.
+#[must_use]
+pub fn get_env_variable(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
+#[inline]
 #[must_use]
 /// Return AWS SDK config with optional region name to use.
-pub async fn get_aws_config(region: Option<String>) -> SdkConfig {
-    aws_config::from_env()
+pub async fn get_aws_config(region: Option<String>, profile: Option<String>) -> SdkConfig {
+    profile
+        .map_or_else(aws_config::from_env, |profile| {
+            aws_config::from_env().profile_name(profile)
+        })
         .region(get_region_provider(region))
         .load()
         .await

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -1,4 +1,4 @@
-use std::{env, fmt};
+use std::fmt;
 
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::aes::{cipher, Aes256};
@@ -39,16 +39,18 @@ pub struct Vault {
 
 impl Vault {
     /// Construct Vault for an existing vault stack with defaults.
+    ///
     /// This will try reading environment variables for the config values,
     /// and otherwise fall back to current AWS config and/or retrieve config values from the
     /// Cloudformation stack description.
     ///
-    /// The Default trait can't be implemented for Vault since it can fail.
+    // The Default trait can't be implemented for Vault since it can fail.
     pub async fn default() -> Result<Self, VaultError> {
-        Self::new(None, None, None, None, None).await
+        Self::new(None, None, None, None, None, None).await
     }
 
     /// Construct Vault for an existing vault stack with optional arguments.
+    ///
     /// This will try reading environment variables for the config values that are `None`.
     pub async fn new(
         vault_stack: Option<String>,
@@ -56,8 +58,9 @@ impl Vault {
         bucket: Option<String>,
         key: Option<String>,
         prefix: Option<String>,
+        profile: Option<String>,
     ) -> Result<Self, VaultError> {
-        let config = crate::get_aws_config(region).await;
+        let config = crate::get_aws_config(region, profile).await;
         let region = config
             .region()
             .map(ToOwned::to_owned)
@@ -66,12 +69,12 @@ impl Vault {
         // Check env variables directly in case the library is not used through the CLI.
         // These are also handled in the CLI, so they are documented in the CLI help.
         let stack_name = vault_stack
-            .or_else(|| get_env_variable("VAULT_STACK"))
+            .or_else(|| crate::get_env_variable("VAULT_STACK"))
             .unwrap_or_else(|| "vault".to_string());
-        let bucket = bucket.or_else(|| get_env_variable("VAULT_BUCKET"));
-        let key = key.or_else(|| get_env_variable("VAULT_KEY"));
+        let bucket = bucket.or_else(|| crate::get_env_variable("VAULT_BUCKET"));
+        let key = key.or_else(|| crate::get_env_variable("VAULT_KEY"));
         let mut prefix = prefix
-            .or_else(|| get_env_variable("VAULT_PREFIX"))
+            .or_else(|| crate::get_env_variable("VAULT_PREFIX"))
             .unwrap_or_default();
 
         if !prefix.is_empty() && !prefix.ends_with('/') {
@@ -105,8 +108,9 @@ impl Vault {
         vault_stack: Option<String>,
         region: Option<String>,
         bucket: Option<String>,
+        profile: Option<String>,
     ) -> Result<CreateStackResult, VaultError> {
-        let config = crate::get_aws_config(region).await;
+        let config = crate::get_aws_config(region, profile).await;
         let region = config
             .region()
             .map(ToOwned::to_owned)
@@ -115,11 +119,11 @@ impl Vault {
         // Check env variables directly in case the library is not used through the CLI.
         // These are also handled in the CLI, so they are documented in the CLI help.
         let stack_name = vault_stack
-            .or_else(|| get_env_variable("VAULT_STACK"))
+            .or_else(|| crate::get_env_variable("VAULT_STACK"))
             .unwrap_or_else(|| "vault".to_string());
 
         let bucket = bucket
-            .or_else(|| get_env_variable("VAULT_BUCKET"))
+            .or_else(|| crate::get_env_variable("VAULT_BUCKET"))
             .unwrap_or({
                 let sts_client = stsClient::new(&config);
                 let identity = sts_client
@@ -420,7 +424,7 @@ impl Vault {
 
         let aesgcm_cipher: AesGcm<Aes256, cipher::typenum::U12> =
             AesGcm::new_from_slice(plaintext.as_ref())?;
-        let nonce = create_random_nonce();
+        let nonce = Self::create_random_nonce();
         let nonce = Nonce::from_slice(nonce.as_slice());
         let meta = Meta::aesgcm(nonce).to_json()?;
         let aes_gcm_ciphertext = aesgcm_cipher
@@ -471,24 +475,22 @@ impl Vault {
             format!("{}{}", self.prefix, name)
         }
     }
+
+    #[inline]
+    fn create_random_nonce() -> [u8; 12] {
+        let mut nonce: [u8; 12] = [0; 12];
+        let mut rng = rand::thread_rng();
+        rng.fill(nonce.as_mut_slice());
+        nonce
+    }
 }
 
 impl fmt::Display for Vault {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "region: {}\n{}", self.region, self.cloudformation_params)
+        write!(f, "region: {}\n{}", self.region, self.cloudformation_params)?;
+        if !self.prefix.is_empty() {
+            write!(f, "\nprefix: {}", self.prefix)?;
+        }
+        Ok(())
     }
-}
-
-#[inline]
-fn create_random_nonce() -> [u8; 12] {
-    let mut nonce: [u8; 12] = [0; 12];
-    let mut rng = rand::thread_rng();
-    rng.fill(nonce.as_mut_slice());
-    nonce
-}
-
-#[inline]
-/// Return possible env variable value as Option.
-fn get_env_variable(name: &str) -> Option<String> {
-    env::var(name).ok()
 }


### PR DESCRIPTION
- Add `--profile` option for specifying AWS profile name to use
- Remove `--id` alias from Rust CLI since it is used differently in the Python version to override IAM id
- Rename `--vault-stack` argument name to `--vaultstack` to match Python version
- Make more short command options visible in the help text 
- Print prefix in vault info if not empty

Looked into implementing the `--id` and `--secret` options for manually specifying IAM id that the Python version has but the aws sdk really does not want you to do that manually, and you need to give token and expiration time too (though these can be `None`). Also, they will be automatically picked up from env variables so better to just let the aws config load handle that instead of having our own manual extra handling for that. The profile option already does basically the same thing in a simpler way.

No need to run nep etc to switch profiles if you already have authenticated previously:
```console
➜  rust git:(rust/cli-tweak) ./vault --profile nitor-core all
pynitor-api-access.json

➜  rust git:(rust/cli-tweak) ./vault --profile nitor-infra all
DigiCertGlobalRootCA.crt.pem
GITHUB_PAT_SELF_HOSTED_RUNNER
GITHUB_SELF_HOSTED_TOKEN-amibakery
GITHUB_SELF_HOSTED_TOKEN
...
```