### PR TITLE
fix path for github actions after rust workspace update

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,8 +33,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.7.5
         if: ${{ matrix.lang == 'rust'}}
-        with:
-          workspaces: ./rust -> target
 
       - uses: actions/setup-go@v5
         if: ${{ matrix.lang == 'go'}}
@@ -86,7 +84,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: 3.x
           cache: pip
 
       - name: Install zip
@@ -237,7 +235,7 @@ jobs:
       - name: Check help output
         run: |
           echo "============================ Python-pyo3 Vault CLI ==========================="
-          vault --help
+          vault -h
           echo "------------------------------------------------------------------------------"
 
           echo "================================ Rust Vault CLI =============================="

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: 3.x
           cache: pip
 
       - name: Install Python dependencies

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: 3.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,18 +8,18 @@ on:
     paths:
       - ".github/workflows/rust.yml"
       - "**.rs"
-      - "rust/Cargo.lock"
-      - "rust/Cargo.toml"
-      - "python-pyo3/Cargo.lock"
+      - "Cargo.lock"
+      - "Cargo.toml"
       - "python-pyo3/Cargo.toml"
+      - "rust/Cargo.toml"
   pull_request:
     paths:
       - ".github/workflows/rust.yml"
       - "**.rs"
-      - "rust/Cargo.lock"
-      - "rust/Cargo.toml"
-      - "python-pyo3/Cargo.lock"
+      - "Cargo.lock"
+      - "Cargo.toml"
       - "python-pyo3/Cargo.toml"
+      - "rust/Cargo.toml"
 
 # Cancel previous runs for PRs but not pushes to main
 concurrency:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,21 +47,6 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2.7.5
-        with:
-          workspaces: ./rust -> target
-
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build
         run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Share version definiton for both Rust and Python-pyo3 packages
+# Share version definition for both Rust and Python-pyo3 packages
 [workspace]
 members = ["rust", "python-pyo3"]
 resolver = "2"

--- a/rust/build.sh
+++ b/rust/build.sh
@@ -24,6 +24,6 @@ else
 fi
 
 rm -f "$executable"
-mv ./target/release/"$executable" "$executable"
+mv ../target/release/"$executable" "$executable"
 file "$executable"
 ./"$executable" --version


### PR DESCRIPTION
Turns out having a Rust workspace means the rust build `target` dir goes to the repo root