### PR TITLE
Python-pyo3: add library interface

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -246,7 +246,7 @@ jobs:
           diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
-        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"
 
       - name: Delete with Python library
         run: python -c "from n_vault import Vault; Vault().delete('secret-python-library')"
@@ -355,7 +355,7 @@ jobs:
           diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
-        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"
 
       - name: Delete with Python library
         run: python -c "from n_vault import Vault; Vault().delete('secret-python-library')"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -346,7 +346,7 @@ jobs:
         run: python -c "from n_vault import Vault; Vault().delete_many(Vault().list_all())"
 
       - name: List with Python library
-        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "0"
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | grep -ve '^\s*$' | wc -l | grep -q "0"
 
       - name: Store secret using Python library
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -218,9 +218,6 @@ jobs:
       - name: Delete secret with Rust
         run: bin/rust/vault -d "secret-${{github.sha}}.zip"
 
-      - name: Verify that key has been deleted with Rust
-        run: bin/rust/vault exists secret-${{github.sha}}.zip | grep -q "does not exist"
-
       - name: Verify that keys have been deleted using Rust
         run: |
           bin/rust/vault exists secret-python | grep -q "key 'secret-python' does not exist"
@@ -228,6 +225,33 @@ jobs:
           bin/rust/vault exists secret-go | grep -q "key 'secret-go' does not exist"
           bin/rust/vault exists secret-rust | grep -q "key 'secret-rust' does not exist"
           bin/rust/vault exists secret-nodejs | grep -q "key 'secret-nodejs' does not exist"
+
+      - name: Check Python vault package
+        run: python -m pip show nitor-vault
+
+      - name: Store secret using Python library
+        run: |
+          python -c "from n_vault import Vault; Vault().store('secret-python-library', 'sha-${{github.sha}}')"
+
+      - name: Verify secret using Python library
+        run: |
+          python -c "from n_vault import Vault; print('true') if Vault().exists('secret-python-library') else print('false')" | grep -q "true"
+
+      - name: Validate storing worked with Rust
+        run: diff <(bin/rust/vault -l secret-python-library) <(echo -n sha-${{github.sha}})
+
+      - name: Lookup with Python library
+        run: |
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end="", flush=True)") <(echo -n sha-${{github.sha}})
+
+      - name: List with Python library
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
+
+      - name: Delete with Python library
+        run: python -c "from n_vault import Vault; Vault().delete('secret-python-library')"
+
+      - name: Verify that key has been deleted with Rust
+        run: bin/rust/vault exists secret-python-library | grep -q "key 'secret-python-library' does not exist"
 
       - name: Install Python PyO3 vault
         run: python -m pip install --force-reinstall .
@@ -310,3 +334,30 @@ jobs:
 
       - name: Verify that key has been deleted with Python-pyo3
         run: vault exists secret-${{github.sha}}.zip | grep -q "does not exist"
+
+      - name: Check Python vault package
+        run: python -m pip show nitor-vault
+
+      - name: Store secret using Python library
+        run: |
+          python -c "from n_vault import Vault; Vault().store('secret-python-library', 'sha-${{github.sha}}')"
+
+      - name: Verify secret using Python library
+        run: |
+          python -c "from n_vault import Vault; print('true') if Vault().exists('secret-python-library') else print('false')" | grep -q "true"
+
+      - name: Validate storing worked with Rust
+        run: diff <(bin/rust/vault -l secret-python-library) <(echo -n sha-${{github.sha}})
+
+      - name: Lookup with Python library
+        run: |
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end="", flush=True)") <(echo -n sha-${{github.sha}})
+
+      - name: List with Python library
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
+
+      - name: Delete with Python library
+        run: python -c "from n_vault import Vault; Vault().delete('secret-python-library')"
+
+      - name: Verify that key has been deleted with Rust
+        run: bin/rust/vault exists secret-python-library | grep -q "key 'secret-python-library' does not exist"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -352,7 +352,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
@@ -352,7 +352,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.7.5
         if: ${{ matrix.lang == 'rust'}}
+        with:
+          # The build script creates a `release` build so use separate cache
+          key: "release"
 
       - uses: actions/setup-go@v5
         if: ${{ matrix.lang == 'go'}}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -339,6 +339,15 @@ jobs:
       - name: Check Python vault package
         run: python -m pip show nitor-vault
 
+      - name: List with Python library
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"
+
+      - name: Delete all keys with Python library
+        run: python -c "from n_vault import Vault; Vault().delete_many(Vault().list_all())"
+
+      - name: List with Python library
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "0"
+
       - name: Store secret using Python library
         run: |
           python -c "from n_vault import Vault; Vault().store('secret-python-library', 'sha-${{github.sha}}')"
@@ -355,7 +364,7 @@ jobs:
           diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
-        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"
+        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
 
       - name: Delete with Python library
         run: python -c "from n_vault import Vault; Vault().delete('secret-python-library')"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -339,9 +339,6 @@ jobs:
       - name: Check Python vault package
         run: python -m pip show nitor-vault
 
-      - name: List with Python library
-        run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))"
-
       - name: Delete all keys with Python library
         run: python -c "from n_vault import Vault; Vault().delete_many(Vault().list_all())"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end="", flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"
@@ -349,7 +349,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end="", flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,8 +8,6 @@ on:
     paths:
       - "!**/README.md"
   pull_request:
-    paths:
-      - "!**/README.md"
 
 permissions:
   id-token: write

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -28,6 +28,11 @@ on:
 permissions:
   contents: read
 
+# Cancel previous runs for PRs but not pushes to main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,8 @@ celerybeat-schedule
 .env
 
 # virtualenv
-venv/
+venv*/
+.venv*/
 ENV/
 
 # Spyder project settings
@@ -112,4 +113,3 @@ dependency-reduced-pom.xml
 # Go binary
 /go/vault
 /go/vault
-.venv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.37"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "shlex",
 ]
@@ -739,9 +739,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -1965,18 +1965,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11611dca53440593f38e6b25ec629de50b14cdfa63adc0fb856115a2c6d97595"
+checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
 dependencies = [
  "clap",
 ]
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault-pyo3"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "nitor-vault",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "2.1.2"
+version = "2.2.0"
 
 [profile.release]
 lto = "thin"

--- a/python-pyo3/README.md
+++ b/python-pyo3/README.md
@@ -112,9 +112,9 @@ Run Python CLI:
 
 ```shell
 # uv
-uv run python/p_vault/vault.py -h
+uv run python/n_vault/cli.py -h
 # venv
-python3 python/p_vault/vault.py -h
+python3 python/n_vault/cli.py -h
 ```
 
 Install and run vault inside virtual env:

--- a/python-pyo3/README.md
+++ b/python-pyo3/README.md
@@ -4,7 +4,7 @@ Python vault implementation using the Rust vault library.
 
 See the [repo](https://github.com/NitorCreations/vault) root readme for more general information.
 
-## Usage
+## Vault CLI
 
 ```console
 Encrypted AWS key-value storage utility
@@ -40,12 +40,13 @@ Options:
   -V, --version            Print version
 ```
 
-## Install
+### Install
 
-### From PyPI
+#### From PyPI
 
 Use [pipx](https://github.com/pypa/pipx) or [uv](https://github.com/astral-sh/uv)
-to install the Python vault package from [PyPI](https://pypi.org/project/nitor-vault/) globally in an isolated environment.
+to install the Python vault package from [PyPI](https://pypi.org/project/nitor-vault/)
+globally in an isolated environment.
 
 ```shell
 pipx install nitor-vault
@@ -55,7 +56,7 @@ uv tool install nitor-vault
 
 The command `vault` should now be available in path.
 
-### From source
+#### From source
 
 Build and install locally from source code using pip.
 This requires a [Rust toolchain](https://rustup.rs/) to be able to build the Rust library.
@@ -75,6 +76,29 @@ and will not be available in path globally.
 
 ```shell
 which -a vault
+```
+
+## Vault library
+
+This Python package can also be used as a Python library to interact with the Vault directly from Python code.
+
+Add the `nitor-vault` package to your project dependencies,
+or install directly with pip.
+
+Example usage:
+
+```python
+from n_vault import Vault
+
+if not Vault().exists("key"):
+    Vault().store("key", "value")
+
+keys = Vault().list_all()
+
+value = Vault().lookup("key")
+
+if Vault().exists("key"):
+    Vault().delete("key")
 ```
 
 ## Development

--- a/python-pyo3/README.md
+++ b/python-pyo3/README.md
@@ -99,6 +99,10 @@ value = Vault().lookup("key")
 
 if Vault().exists("key"):
     Vault().delete("key")
+
+# specify vault parameters
+vault = Vault(vault_stack="stack-name", profile="aws-credentials-name")
+value = vault.lookup("key")
 ```
 
 ## Development

--- a/python-pyo3/pyproject.toml
+++ b/python-pyo3/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-build = ["maturin", "twine", "wheel"]
-dev = ["ruff"]
+build = ["maturin", "wheel"]
+dev = ["maturin", "ruff"]
 
 [project.urls]
 Repository = "https://github.com/NitorCreations/vault"

--- a/python-pyo3/pyproject.toml
+++ b/python-pyo3/pyproject.toml
@@ -60,7 +60,7 @@ venv = ".venv"
 [tool.ruff]
 # https://docs.astral.sh/ruff/configuration/
 include = ["*.py", "*.pyi", "**/pyproject.toml"]
-target-version = "py311"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/python-pyo3/pyproject.toml
+++ b/python-pyo3/pyproject.toml
@@ -37,7 +37,7 @@ dev = ["ruff"]
 Repository = "https://github.com/NitorCreations/vault"
 
 [project.scripts]
-vault = "p_vault.vault:main"
+vault = "n_vault.cli:main"
 
 [build-system]
 requires = ["maturin>=1.7,<2.0"]
@@ -46,9 +46,9 @@ build-backend = "maturin"
 [tool.maturin]
 bindings = "pyo3"
 features = ["pyo3/extension-module"]
-module-name = "p_vault.nitor_vault_rs"
+module-name = "n_vault.nitor_vault_rs"
 profile = "release"
-python-packages = ["p_vault"]
+python-packages = ["n_vault"]
 python-source = "python"
 strip = true
 

--- a/python-pyo3/pyproject.toml
+++ b/python-pyo3/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
     { name = "Pasi Niemi", email = "pasi@nitor.com" },
     { name = "Akseli Lukkarila", email = "akseli.lukkarila@nitor.com" },
 ]
-license = { text = "Apache 2.0" }
+license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -35,6 +35,7 @@ dev = ["ruff"]
 
 [project.urls]
 Repository = "https://github.com/NitorCreations/vault"
+Homepage = "https://github.com/NitorCreations/vault"
 
 [project.scripts]
 vault = "n_vault.cli:main"

--- a/python-pyo3/python/n_vault/__init__.py
+++ b/python-pyo3/python/n_vault/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2016-2024 Nitor Creations Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Vault module for securely storing secrets in s3 with local encryption with data keys from AWS KMS.
+"""
+
+# Simplify importing for library users,
+# so one can simply do:
+# from n_vault import Vault
+
+from n_vault.vault import Vault as Vault  # noqa: E402

--- a/python-pyo3/python/n_vault/__init__.py
+++ b/python-pyo3/python/n_vault/__init__.py
@@ -16,8 +16,7 @@
 Vault module for securely storing secrets in s3 with local encryption with data keys from AWS KMS.
 """
 
-# Simplify importing for library users,
-# so one can simply do:
-# from n_vault import Vault
+# Simplify importing for library users, enabling:
+# `from n_vault import Vault`
 
 from n_vault.vault import Vault as Vault  # noqa: E402

--- a/python-pyo3/python/n_vault/cli.py
+++ b/python-pyo3/python/n_vault/cli.py
@@ -1,6 +1,6 @@
 import sys
 
-from p_vault import nitor_vault_rs
+from n_vault import nitor_vault_rs
 
 
 def main():

--- a/python-pyo3/python/n_vault/cli.py
+++ b/python-pyo3/python/n_vault/cli.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2024 Nitor Creations Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 
 from n_vault import nitor_vault_rs

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -16,6 +16,7 @@ import os
 
 from collections.abc import Collection
 from dataclasses import dataclass
+from typing import Optional
 
 from n_vault import nitor_vault_rs
 
@@ -25,11 +26,11 @@ class CloudFormationStackData:
     """Vault stack data from AWS CloudFormation describe stack."""
 
     result: str
-    bucket: str | None
-    key: str | None
-    status: str | None
-    status_reason: str | None
-    version: int | None
+    bucket: Optional[str]
+    key: Optional[str]
+    status: Optional[str]
+    status_reason: Optional[str]
+    version: Optional[int]
 
 
 @dataclass
@@ -37,9 +38,9 @@ class StackCreated:
     """Result data for vault init."""
 
     result: str
-    stack_name: str | None
-    stack_id: str | None
-    region: str | None
+    stack_name: Optional[str]
+    stack_id: Optional[str]
+    region: Optional[str]
 
 
 @dataclass
@@ -47,9 +48,9 @@ class StackUpdated:
     """Result data for vault update."""
 
     result: str
-    stack_id: str | None
-    previous_version: int | None
-    new_version: int | None
+    stack_id: Optional[str]
+    previous_version: Optional[int]
+    new_version: Optional[int]
 
 
 class Vault:

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -99,6 +99,16 @@ class Vault:
             profile=self.profile,
         )
 
+    def stack_status(self) -> dict[str]:
+        return nitor_vault_rs.stack_status(
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
+
     def store(self, key: str, value: bytes | str) -> None:
         if isinstance(value, str):
             value = value.encode("utf-8")

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -21,29 +21,87 @@ from n_vault import nitor_vault_rs
 class Vault:
     """Nitor Vault wrapper around the Rust vault library."""
 
-    @staticmethod
-    def delete(name: str) -> None:
-        return nitor_vault_rs.delete(name)
+    def __init__(
+        self,
+        vault_stack: str = None,
+        region: str = None,
+        bucket: str = None,
+        key: str = None,
+        prefix: str = None,
+        profile: str = None,
+    ):
+        self.vault_stack = vault_stack
+        self.region = region
+        self.bucket = bucket
+        self.key = key
+        self.prefix = prefix
+        self.profile = profile
 
-    @staticmethod
-    def delete_many(names: Collection[str]) -> None:
-        return nitor_vault_rs.delete_many(sorted(names))
+    def delete(self, name: str) -> None:
+        return nitor_vault_rs.delete(
+            name,
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
 
-    @staticmethod
-    def exists(name: str) -> bool:
-        return nitor_vault_rs.exists(name)
+    def delete_many(self, names: Collection[str]) -> None:
+        return nitor_vault_rs.delete_many(
+            sorted(names),
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
 
-    @staticmethod
-    def list_all() -> list[str]:
-        return nitor_vault_rs.list_all()
+    def exists(self, name: str) -> bool:
+        return nitor_vault_rs.exists(
+            name,
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
 
-    @staticmethod
-    def lookup(name: str) -> str:
-        return nitor_vault_rs.lookup(name)
+    def list_all(self) -> list[str]:
+        return nitor_vault_rs.list_all(
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
 
-    @staticmethod
-    def store(key: str, value: bytes | str) -> None:
+    def lookup(self, name: str) -> str:
+        return nitor_vault_rs.lookup(
+            name,
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
+
+    def store(self, key: str, value: bytes | str) -> None:
         if isinstance(value, str):
             value = value.encode("utf-8")
 
-        return nitor_vault_rs.store(key, value)
+        return nitor_vault_rs.store(
+            key,
+            value,
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -114,6 +114,37 @@ class Vault:
             profile=self.profile,
         )
 
+    def direct_decrypt(self, data: bytes) -> bytes:
+        """
+        Decrypt data with KMS.
+        """
+        return nitor_vault_rs.direct_decrypt(
+            data,
+            vault_stack=self.vault_stack,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
+            key=self.vault_key,
+            prefix=self.vault_prefix,
+            profile=self.profile,
+        )
+
+    def direct_encrypt(self, data: bytes | str) -> bytes:
+        """
+        Encrypt data with KMS.
+        """
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+
+        return nitor_vault_rs.direct_encrypt(
+            data,
+            vault_stack=self.vault_stack,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
+            key=self.vault_key,
+            prefix=self.vault_prefix,
+            profile=self.profile,
+        )
+
     def exists(self, name: str) -> bool:
         """
         Check if the given key name already exists in the S3 bucket.

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -114,12 +114,12 @@ class Vault:
             profile=self.profile,
         )
 
-    def direct_decrypt(self, data: bytes) -> bytes:
+    def direct_decrypt(self, encrypted_data: bytes) -> bytes:
         """
         Decrypt data with KMS.
         """
         return nitor_vault_rs.direct_decrypt(
-            data,
+            encrypted_data,
             vault_stack=self.vault_stack,
             region=self.vault_region,
             bucket=self.vault_bucket,

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -1,3 +1,18 @@
+# Copyright 2016-2024 Nitor Creations Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from n_vault import nitor_vault_rs
 
 

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
 from collections.abc import Collection
 from dataclasses import dataclass
@@ -61,16 +62,22 @@ class Vault:
         vault_stack: str = None,
         region: str = None,
         bucket: str = None,
-        key: str = None,
+        vault_key: str = None,
         prefix: str = None,
         profile: str = None,
     ):
         self.vault_stack = vault_stack
         self.region = region
         self.bucket = bucket
-        self.key = key
+        self.vault_key = vault_key
         self.prefix = prefix
         self.profile = profile
+
+    def all(self) -> str:
+        """
+        Return a string with all keys separated by os.linesep.
+        """
+        return os.linesep.join(item for item in self.list_all())
 
     def delete(self, name: str) -> None:
         """
@@ -81,7 +88,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -97,7 +104,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -113,7 +120,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -152,7 +159,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -168,7 +175,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -181,26 +188,26 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
         return CloudFormationStackData(**data)
 
-    def store(self, key: str, value: bytes | str) -> None:
+    def store(self, name: str, data: bytes | str) -> None:
         """
         Store encrypted value with given key name in S3.
         """
-        if isinstance(value, str):
-            value = value.encode("utf-8")
+        if isinstance(name, str):
+            name = name.encode("utf-8")
 
         return nitor_vault_rs.store(
-            key,
-            value,
+            name,
+            data,
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )
@@ -216,7 +223,7 @@ class Vault:
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,
-            key=self.key,
+            key=self.vault_key,
             prefix=self.prefix,
             profile=self.profile,
         )

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -198,8 +198,8 @@ class Vault:
         """
         Store encrypted value with given key name in S3.
         """
-        if isinstance(name, str):
-            name = name.encode("utf-8")
+        if isinstance(data, str):
+            data = data.encode("utf-8")
 
         return nitor_vault_rs.store(
             name,

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -16,7 +16,7 @@ import os
 
 from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from n_vault import nitor_vault_rs
 
@@ -128,7 +128,7 @@ class Vault:
             profile=self.profile,
         )
 
-    def direct_encrypt(self, data: bytes | str) -> bytes:
+    def direct_encrypt(self, data: Union[bytes, str]) -> bytes:
         """
         Encrypt data with KMS.
         """
@@ -161,7 +161,7 @@ class Vault:
             profile=self.profile,
         )
 
-    def init(self) -> StackCreated | CloudFormationStackData:
+    def init(self) -> Union[StackCreated, CloudFormationStackData]:
         """
         Initialize new Vault stack.
 
@@ -230,7 +230,7 @@ class Vault:
         )
         return CloudFormationStackData(**data)
 
-    def store(self, name: str, data: bytes | str) -> None:
+    def store(self, name: str, data: Union[bytes, str]) -> None:
         """
         Store encrypted value with given key name in S3.
         """
@@ -248,7 +248,7 @@ class Vault:
             profile=self.profile,
         )
 
-    def update(self) -> StackUpdated | CloudFormationStackData:
+    def update(self) -> Union[StackUpdated, CloudFormationStackData]:
         """
         Update the vault Cloudformation stack with the current template.
 

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -55,23 +55,27 @@ class StackUpdated:
 
 class Vault:
     """
-    Nitor Vault wrapper around the Rust vault library.
+    Nitor Vault Python wrapper class around the Rust vault library.
+
+    Note that initializing this class only saves the optional parameters,
+    but does *not* construct an actual vault instance.
+    Each method in this class creates its own Vault instance internally in the Rust library.
     """
 
     def __init__(
         self,
         vault_stack: str = None,
-        region: str = None,
-        bucket: str = None,
         vault_key: str = None,
-        prefix: str = None,
+        vault_bucket: str = None,
+        vault_prefix: str = None,
+        vault_region: str = None,
         profile: str = None,
     ):
         self.vault_stack = vault_stack
-        self.region = region
-        self.bucket = bucket
         self.vault_key = vault_key
-        self.prefix = prefix
+        self.vault_bucket = vault_bucket
+        self.vault_prefix = vault_prefix
+        self.vault_region = vault_region
         self.profile = profile
 
     def all(self) -> str:
@@ -87,10 +91,10 @@ class Vault:
         return nitor_vault_rs.delete(
             name,
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -103,10 +107,10 @@ class Vault:
         return nitor_vault_rs.delete_many(
             sorted(names),
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -119,10 +123,10 @@ class Vault:
         return nitor_vault_rs.exists(
             name,
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -138,8 +142,8 @@ class Vault:
         """
         result = nitor_vault_rs.init(
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             profile=self.profile,
         )
         result_status = result.get("result")
@@ -158,10 +162,10 @@ class Vault:
         """
         return nitor_vault_rs.list_all(
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -174,10 +178,10 @@ class Vault:
         return nitor_vault_rs.lookup(
             name,
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -187,10 +191,10 @@ class Vault:
         """
         data = nitor_vault_rs.stack_status(
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
         return CloudFormationStackData(**data)
@@ -206,10 +210,10 @@ class Vault:
             name,
             data,
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
 
@@ -222,10 +226,10 @@ class Vault:
         """
         result = nitor_vault_rs.update(
             vault_stack=self.vault_stack,
-            region=self.region,
-            bucket=self.bucket,
+            region=self.vault_region,
+            bucket=self.vault_bucket,
             key=self.vault_key,
-            prefix=self.prefix,
+            prefix=self.vault_prefix,
             profile=self.profile,
         )
         result_status = result.get("result")

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -89,6 +89,11 @@ class Vault:
         )
 
     def exists(self, name: str) -> bool:
+        """
+        Check if the given key name already exists in the S3 bucket.
+
+        Returns True if the key exists, False otherwise.
+        """
         return nitor_vault_rs.exists(
             name,
             vault_stack=self.vault_stack,
@@ -100,6 +105,15 @@ class Vault:
         )
 
     def init(self) -> StackCreated | CloudFormationStackData:
+        """
+        Initialize new Vault stack.
+
+        This will create all required resources in AWS,
+        after which the Vault can be used to store and lookup values.
+
+        Returns a `StackCreated` if a new vault stack was initialized,
+        or `CloudFormationStackData` if it already exists.
+        """
         result = nitor_vault_rs.init(
             vault_stack=self.vault_stack,
             region=self.region,
@@ -115,6 +129,11 @@ class Vault:
         raise RuntimeError(f"Unexpected result data: {result}")
 
     def list_all(self) -> list[str]:
+        """
+        Get all available secrets.
+
+        Returns a list of key names.
+        """
         return nitor_vault_rs.list_all(
             vault_stack=self.vault_stack,
             region=self.region,
@@ -152,6 +171,9 @@ class Vault:
         return CloudFormationStackData(**data)
 
     def store(self, key: str, value: bytes | str) -> None:
+        """
+        Store encrypted value with given key name in S3.
+        """
         if isinstance(value, str):
             value = value.encode("utf-8")
 
@@ -167,6 +189,12 @@ class Vault:
         )
 
     def update(self) -> StackUpdated | CloudFormationStackData:
+        """
+        Update the vault Cloudformation stack with the current template.
+
+        Returns `StackUpdated` if the vault stack was updated to a new version,
+        or `CloudFormationStackData` if it is already up to date.
+        """
         result = nitor_vault_rs.update(
             vault_stack=self.vault_stack,
             region=self.region,

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -20,16 +20,20 @@ class Vault:
     """Nitor Vault wrapper around the Rust vault library."""
 
     @staticmethod
-    def lookup(name: str) -> str:
-        return nitor_vault_rs.lookup(name)
+    def delete(name: str) -> None:
+        return nitor_vault_rs.delete(name)
+
+    @staticmethod
+    def exists(name: str) -> bool:
+        return nitor_vault_rs.exists(name)
 
     @staticmethod
     def list_all() -> list[str]:
         return nitor_vault_rs.list_all()
 
     @staticmethod
-    def delete(name: str) -> None:
-        return nitor_vault_rs.delete(name)
+    def lookup(name: str) -> str:
+        return nitor_vault_rs.lookup(name)
 
     @staticmethod
     def store(key: str, value: bytes | str) -> None:
@@ -37,7 +41,3 @@ class Vault:
             value = value.encode("utf-8")
 
         return nitor_vault_rs.store(key, value)
-
-    @staticmethod
-    def exists(name: str) -> bool:
-        return nitor_vault_rs.exists(name)

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -26,3 +26,18 @@ class Vault:
     @staticmethod
     def list_all() -> list[str]:
         return nitor_vault_rs.list_all()
+
+    @staticmethod
+    def delete(name: str) -> None:
+        return nitor_vault_rs.delete(name)
+
+    @staticmethod
+    def store(key: str, value: bytes | str) -> None:
+        if isinstance(value, str):
+            value = value.encode("utf-8")
+
+        return nitor_vault_rs.store(key, value)
+
+    @staticmethod
+    def exists(name: str) -> bool:
+        return nitor_vault_rs.exists(name)

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -1,0 +1,13 @@
+from n_vault import nitor_vault_rs
+
+
+class Vault:
+    """Nitor Vault wrapper around the Rust vault library."""
+
+    @staticmethod
+    def lookup(name: str) -> str:
+        return nitor_vault_rs.lookup(name)
+
+    @staticmethod
+    def list_all() -> list[str]:
+        return nitor_vault_rs.list_all()

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -33,6 +33,8 @@ class CloudFormationStackData:
 
 @dataclass
 class StackCreated:
+    """Result data for vault init."""
+
     result: str
     stack_name: str | None
     stack_id: str | None
@@ -41,6 +43,8 @@ class StackCreated:
 
 @dataclass
 class StackUpdated:
+    """Result data for vault update."""
+
     result: str
     stack_id: str | None
     previous_version: int | None
@@ -48,7 +52,9 @@ class StackUpdated:
 
 
 class Vault:
-    """Nitor Vault wrapper around the Rust vault library."""
+    """
+    Nitor Vault wrapper around the Rust vault library.
+    """
 
     def __init__(
         self,
@@ -67,6 +73,9 @@ class Vault:
         self.profile = profile
 
     def delete(self, name: str) -> None:
+        """
+        Delete data in S3 for given key name.
+        """
         return nitor_vault_rs.delete(
             name,
             vault_stack=self.vault_stack,
@@ -78,6 +87,11 @@ class Vault:
         )
 
     def delete_many(self, names: Collection[str]) -> None:
+        """
+        Delete data for multiple keys.
+
+        Takes in a collection of key name strings, such as a `list`, `tuple`, or `set`.
+        """
         return nitor_vault_rs.delete_many(
             sorted(names),
             vault_stack=self.vault_stack,
@@ -160,6 +174,9 @@ class Vault:
         )
 
     def stack_status(self) -> CloudFormationStackData:
+        """
+        Get vault Cloudformation stack status.
+        """
         data = nitor_vault_rs.stack_status(
             vault_stack=self.vault_stack,
             region=self.region,

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -70,6 +70,14 @@ class Vault:
             profile=self.profile,
         )
 
+    def init(self) -> dict[str]:
+        return nitor_vault_rs.init(
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            profile=self.profile,
+        )
+
     def list_all(self) -> list[str]:
         return nitor_vault_rs.list_all(
             vault_stack=self.vault_stack,
@@ -98,6 +106,16 @@ class Vault:
         return nitor_vault_rs.store(
             key,
             value,
+            vault_stack=self.vault_stack,
+            region=self.region,
+            bucket=self.bucket,
+            key=self.key,
+            prefix=self.prefix,
+            profile=self.profile,
+        )
+
+    def update(self) -> dict[str]:
+        return nitor_vault_rs.update(
             vault_stack=self.vault_stack,
             region=self.region,
             bucket=self.bucket,

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from collections.abc import Collection
+
 from n_vault import nitor_vault_rs
 
 
@@ -22,6 +24,10 @@ class Vault:
     @staticmethod
     def delete(name: str) -> None:
         return nitor_vault_rs.delete(name)
+
+    @staticmethod
+    def delete_many(names: Collection[str]) -> None:
+        return nitor_vault_rs.delete_many(sorted(names))
 
     @staticmethod
     def exists(name: str) -> bool:

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -21,6 +21,19 @@ fn delete(name: &str) -> PyResult<()> {
 }
 
 #[pyfunction]
+#[allow(clippy::needless_pass_by_value)]
+fn delete_many(names: Vec<String>) -> PyResult<()> {
+    Runtime::new()?.block_on(async {
+        Ok(Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .delete_many(&names)
+            .await
+            .map_err(vault_error_to_anyhow)?)
+    })
+}
+
+#[pyfunction]
 fn exists(name: &str) -> PyResult<bool> {
     Runtime::new()?.block_on(async {
         let result: bool = Vault::default()
@@ -91,6 +104,7 @@ fn store(key: &str, value: &[u8]) -> PyResult<()> {
 #[pyo3(name = "nitor_vault_rs")]
 fn nitor_vault_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(delete, m)?)?;
+    m.add_function(wrap_pyfunction!(delete_many, m)?)?;
     m.add_function(wrap_pyfunction!(exists, m)?)?;
     m.add_function(wrap_pyfunction!(list_all, m)?)?;
     m.add_function(wrap_pyfunction!(lookup, m)?)?;

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -15,8 +15,8 @@ fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
 
 /// Convert `CloudFormationStackData` to a Python dictionary.
 // Lifetime annotations are required due to `&str` usage,
-// could be left out if passing a `String` for result message.
-fn stack_data_to_to_pydict<'a>(
+// could be left out if passing a `String` for the result message.
+fn stack_data_to_pydict<'a>(
     py: Python<'a>,
     data: CloudFormationStackData,
     result: &'a str,
@@ -162,11 +162,11 @@ fn init(
     })?;
     Python::with_gil(|py| match result {
         CreateStackResult::Exists { data } => {
-            let dict = stack_data_to_to_pydict(py, data, "EXISTS");
+            let dict = stack_data_to_pydict(py, data, "EXISTS");
             Ok(dict.into())
         }
         CreateStackResult::ExistsWithFailedState { data } => {
-            let dict = stack_data_to_to_pydict(py, data, "EXISTS_WITH_FAILED_STATE");
+            let dict = stack_data_to_pydict(py, data, "EXISTS_WITH_FAILED_STATE");
             Ok(dict.into())
         }
         CreateStackResult::Created {
@@ -260,7 +260,7 @@ fn stack_status(
     })?;
 
     Python::with_gil(|py| {
-        let dict = stack_data_to_to_pydict(py, data, "SUCCESS");
+        let dict = stack_data_to_pydict(py, data, "SUCCESS");
         Ok(dict.into())
     })
 }
@@ -308,7 +308,7 @@ fn update(
 
     Python::with_gil(|py| match result {
         UpdateStackResult::UpToDate { data } => {
-            let dict = stack_data_to_to_pydict(py, data, "UP_TO_DATE");
+            let dict = stack_data_to_pydict(py, data, "UP_TO_DATE");
             Ok(dict.into())
         }
         UpdateStackResult::Updated {

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -10,6 +10,9 @@ fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
     err.into()
 }
 
+/// Convert `CloudFormationStackData` to a Python dictionary.
+// Lifetime annotations are required due to `&str` usage,
+// could be left out if passing a `String` for result message.
 fn stack_data_to_to_pydict<'a>(
     py: Python<'a>,
     data: CloudFormationStackData,
@@ -111,12 +114,10 @@ fn init(
     Python::with_gil(|py| match result {
         CreateStackResult::Exists { data } => {
             let dict = stack_data_to_to_pydict(py, data, "EXISTS");
-
             Ok(dict.into())
         }
         CreateStackResult::ExistsWithFailedState { data } => {
             let dict = stack_data_to_to_pydict(py, data, "EXISTS_WITH_FAILED_STATE");
-
             Ok(dict.into())
         }
         CreateStackResult::Created {
@@ -130,7 +131,6 @@ fn init(
                 ("stack_id", stack_id.to_object(py)),
                 ("region", region.to_string().to_object(py)),
             ];
-
             let dict = key_vals.into_py_dict_bound(py);
             Ok(dict.into())
         }
@@ -178,6 +178,7 @@ fn lookup(
         .await
         .map_err(vault_error_to_anyhow)?;
 
+        // Binary data will get base64 encoded in the Display trait implementation
         Ok(result.to_string())
     })
 }
@@ -211,7 +212,6 @@ fn stack_status(
 
     Python::with_gil(|py| {
         let dict = stack_data_to_to_pydict(py, data, "SUCCESS");
-
         Ok(dict.into())
     })
 }
@@ -260,7 +260,6 @@ fn update(
     Python::with_gil(|py| match result {
         UpdateStackResult::UpToDate { data } => {
             let dict = stack_data_to_to_pydict(py, data, "UP_TO_DATE");
-
             Ok(dict.into())
         }
         UpdateStackResult::Updated {
@@ -274,7 +273,6 @@ fn update(
                 ("previous_version", previous_version.to_object(py)),
                 ("new_version", new_version.to_object(py)),
             ];
-
             let dict = key_vals.into_py_dict_bound(py);
             Ok(dict.into())
         }

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -1,5 +1,12 @@
+use nitor_vault::errors::VaultError;
+use nitor_vault::{Value, Vault};
 use pyo3::prelude::*;
 use tokio::runtime::Runtime;
+
+/// Convert `VaultError` to `anyhow::Error`
+fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
+    err.into()
+}
 
 #[pyfunction]
 fn run(args: Vec<String>) -> PyResult<()> {
@@ -9,9 +16,37 @@ fn run(args: Vec<String>) -> PyResult<()> {
     })
 }
 
+#[pyfunction]
+fn lookup(name: &str) -> PyResult<String> {
+    Runtime::new()?.block_on(async {
+        let result: Value = Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .lookup(name)
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result.to_string())
+    })
+}
+
+#[pyfunction]
+fn list_all() -> PyResult<Vec<String>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .all()
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result)
+    })
+}
+
 #[pymodule]
 #[pyo3(name = "nitor_vault_rs")]
-fn vault(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run, m)?)?;
+    m.add_function(wrap_pyfunction!(lookup, m)?)?;
+    m.add_function(wrap_pyfunction!(list_all, m)?)?;
     Ok(())
 }

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -77,6 +77,50 @@ fn delete_many(
     })
 }
 
+#[pyfunction(signature = (data, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn direct_decrypt(
+    data: &[u8],
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<Vec<u8>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::new(vault_stack, region, bucket, key, prefix, profile)
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .direct_decrypt(data)
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result)
+    })
+}
+
+#[pyfunction(signature = (data, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn direct_encrypt(
+    data: &[u8],
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<Vec<u8>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::new(vault_stack, region, bucket, key, prefix, profile)
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .direct_encrypt(data)
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result)
+    })
+}
+
 #[pyfunction(signature = (name, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
 fn exists(
     name: &str,
@@ -284,6 +328,8 @@ fn update(
 fn nitor_vault_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(delete, m)?)?;
     m.add_function(wrap_pyfunction!(delete_many, m)?)?;
+    m.add_function(wrap_pyfunction!(direct_decrypt, m)?)?;
+    m.add_function(wrap_pyfunction!(direct_encrypt, m)?)?;
     m.add_function(wrap_pyfunction!(exists, m)?)?;
     m.add_function(wrap_pyfunction!(init, m)?)?;
     m.add_function(wrap_pyfunction!(list_all, m)?)?;

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -8,35 +8,63 @@ fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
     err.into()
 }
 
-#[pyfunction]
-fn delete(name: &str) -> PyResult<()> {
+#[pyfunction(signature = (name, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn delete(
+    name: &str,
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<()> {
     Runtime::new()?.block_on(async {
-        Ok(Vault::default()
-            .await
-            .map_err(vault_error_to_anyhow)?
-            .delete(name)
-            .await
-            .map_err(vault_error_to_anyhow)?)
+        Ok(
+            Vault::new(vault_stack, region, bucket, key, prefix, profile)
+                .await
+                .map_err(vault_error_to_anyhow)?
+                .delete(name)
+                .await
+                .map_err(vault_error_to_anyhow)?,
+        )
     })
 }
 
-#[pyfunction]
+#[pyfunction(signature = (names, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
 #[allow(clippy::needless_pass_by_value)]
-fn delete_many(names: Vec<String>) -> PyResult<()> {
+fn delete_many(
+    names: Vec<String>,
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<()> {
     Runtime::new()?.block_on(async {
-        Ok(Vault::default()
-            .await
-            .map_err(vault_error_to_anyhow)?
-            .delete_many(&names)
-            .await
-            .map_err(vault_error_to_anyhow)?)
+        Ok(
+            Vault::new(vault_stack, region, bucket, key, prefix, profile)
+                .await
+                .map_err(vault_error_to_anyhow)?
+                .delete_many(&names)
+                .await
+                .map_err(vault_error_to_anyhow)?,
+        )
     })
 }
 
-#[pyfunction]
-fn exists(name: &str) -> PyResult<bool> {
+#[pyfunction(signature = (name, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn exists(
+    name: &str,
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<bool> {
     Runtime::new()?.block_on(async {
-        let result: bool = Vault::default()
+        let result: bool = Vault::new(vault_stack, region, bucket, key, prefix, profile)
             .await
             .map_err(vault_error_to_anyhow)?
             .exists(name)
@@ -47,10 +75,17 @@ fn exists(name: &str) -> PyResult<bool> {
     })
 }
 
-#[pyfunction]
-fn list_all() -> PyResult<Vec<String>> {
+#[pyfunction(signature = (vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn list_all(
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<Vec<String>> {
     Runtime::new()?.block_on(async {
-        let result = Vault::default()
+        let result = Vault::new(vault_stack, region, bucket, key, prefix, profile)
             .await
             .map_err(vault_error_to_anyhow)?
             .all()
@@ -61,11 +96,19 @@ fn list_all() -> PyResult<Vec<String>> {
     })
 }
 
-#[pyfunction]
-fn lookup(name: &str) -> PyResult<String> {
+#[pyfunction(signature = (name, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn lookup(
+    name: &str,
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<String> {
     Runtime::new()?.block_on(async {
         let result: Value = Box::pin(
-            Vault::default()
+            Vault::new(vault_stack, region, bucket, key, prefix, profile)
                 .await
                 .map_err(vault_error_to_anyhow)?
                 .lookup(name),
@@ -86,14 +129,23 @@ fn run(args: Vec<String>) -> PyResult<()> {
     })
 }
 
-#[pyfunction]
-fn store(key: &str, value: &[u8]) -> PyResult<()> {
+#[pyfunction(signature = (name, value, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn store(
+    name: &str,
+    value: &[u8],
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<()> {
     Runtime::new()?.block_on(async {
         Ok(Box::pin(
-            Vault::default()
+            Vault::new(vault_stack, region, bucket, key, prefix, profile)
                 .await
                 .map_err(vault_error_to_anyhow)?
-                .store(key, value),
+                .store(name, value),
         )
         .await
         .map_err(vault_error_to_anyhow)?)

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -9,10 +9,42 @@ fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
 }
 
 #[pyfunction]
-fn run(args: Vec<String>) -> PyResult<()> {
+fn delete(name: &str) -> PyResult<()> {
     Runtime::new()?.block_on(async {
-        nitor_vault::run_cli_with_args(args).await?;
-        Ok(())
+        Ok(Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .delete(name)
+            .await
+            .map_err(vault_error_to_anyhow)?)
+    })
+}
+
+#[pyfunction]
+fn exists(name: &str) -> PyResult<bool> {
+    Runtime::new()?.block_on(async {
+        let result: bool = Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .exists(name)
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result)
+    })
+}
+
+#[pyfunction]
+fn list_all() -> PyResult<Vec<String>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::default()
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .all()
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(result)
     })
 }
 
@@ -33,24 +65,36 @@ fn lookup(name: &str) -> PyResult<String> {
 }
 
 #[pyfunction]
-fn list_all() -> PyResult<Vec<String>> {
+/// Run Vault CLI with given args.
+fn run(args: Vec<String>) -> PyResult<()> {
     Runtime::new()?.block_on(async {
-        let result = Vault::default()
-            .await
-            .map_err(vault_error_to_anyhow)?
-            .all()
-            .await
-            .map_err(vault_error_to_anyhow)?;
+        nitor_vault::run_cli_with_args(args).await?;
+        Ok(())
+    })
+}
 
-        Ok(result)
+#[pyfunction]
+fn store(key: &str, value: &[u8]) -> PyResult<()> {
+    Runtime::new()?.block_on(async {
+        Ok(Box::pin(
+            Vault::default()
+                .await
+                .map_err(vault_error_to_anyhow)?
+                .store(key, value),
+        )
+        .await
+        .map_err(vault_error_to_anyhow)?)
     })
 }
 
 #[pymodule]
 #[pyo3(name = "nitor_vault_rs")]
 fn nitor_vault_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(run, m)?)?;
-    m.add_function(wrap_pyfunction!(lookup, m)?)?;
+    m.add_function(wrap_pyfunction!(delete, m)?)?;
+    m.add_function(wrap_pyfunction!(exists, m)?)?;
     m.add_function(wrap_pyfunction!(list_all, m)?)?;
+    m.add_function(wrap_pyfunction!(lookup, m)?)?;
+    m.add_function(wrap_pyfunction!(run, m)?)?;
+    m.add_function(wrap_pyfunction!(store, m)?)?;
     Ok(())
 }

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -1,11 +1,46 @@
+use std::collections::HashMap;
+
+use nitor_vault::cloudformation::CloudFormationStackData;
 use nitor_vault::errors::VaultError;
-use nitor_vault::{Value, Vault};
+use nitor_vault::{CreateStackResult, UpdateStackResult, Value, Vault};
 use pyo3::prelude::*;
 use tokio::runtime::Runtime;
 
 /// Convert `VaultError` to `anyhow::Error`
 fn vault_error_to_anyhow(err: VaultError) -> anyhow::Error {
     err.into()
+}
+
+fn to_hash_map(stack_data: CloudFormationStackData, result: String) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    map.insert("result".to_string(), result);
+    map.insert(
+        "bucket_name".to_string(),
+        stack_data.bucket_name.clone().unwrap_or_default(),
+    );
+    map.insert(
+        "key_arn".to_string(),
+        stack_data.key_arn.clone().unwrap_or_default(),
+    );
+    map.insert(
+        "version".to_string(),
+        stack_data
+            .version
+            .map_or_else(String::new, |v| v.to_string()),
+    );
+    map.insert(
+        "status".to_string(),
+        stack_data
+            .status
+            .as_ref()
+            .map_or_else(String::new, std::string::ToString::to_string),
+    );
+    map.insert(
+        "status_reason".to_string(),
+        stack_data.status_reason.unwrap_or_default(),
+    );
+
+    map
 }
 
 #[pyfunction(signature = (name, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
@@ -72,6 +107,38 @@ fn exists(
             .map_err(vault_error_to_anyhow)?;
 
         Ok(result)
+    })
+}
+
+#[pyfunction(signature = (vault_stack=None, region=None, bucket=None, profile=None))]
+fn init(
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    profile: Option<String>,
+) -> PyResult<HashMap<String, String>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::init(vault_stack, region, bucket, profile)
+            .await
+            .map_err(vault_error_to_anyhow)?;
+        match result {
+            CreateStackResult::Exists { data } => Ok(to_hash_map(data, "exists".to_string())),
+            CreateStackResult::ExistsWithFailedState { data } => {
+                Ok(to_hash_map(data, "error".to_string()))
+            }
+            CreateStackResult::Created {
+                stack_name,
+                stack_id,
+                region,
+            } => {
+                let mut dict = HashMap::new();
+                dict.insert("result".to_string(), "created".to_string());
+                dict.insert("stack_name".to_string(), stack_name);
+                dict.insert("stack_id".to_string(), stack_id);
+                dict.insert("region".to_string(), region.to_string());
+                Ok(dict)
+            }
+        }
     })
 }
 
@@ -152,15 +219,52 @@ fn store(
     })
 }
 
+#[pyfunction(signature = (vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn update(
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<HashMap<String, String>> {
+    Runtime::new()?.block_on(async {
+        let result = Vault::new(vault_stack, region, bucket, key, prefix, profile)
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .update_stack()
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        match result {
+            UpdateStackResult::UpToDate { data } => Ok(to_hash_map(data, "up-to-date".to_string())),
+            UpdateStackResult::Updated {
+                stack_id,
+                previous_version,
+                new_version,
+            } => {
+                let mut map = HashMap::new();
+                map.insert("result".to_string(), "updated".to_string());
+                map.insert("stack_id".to_string(), stack_id);
+                map.insert("previous_version".to_string(), previous_version.to_string());
+                map.insert("new_version".to_string(), new_version.to_string());
+                Ok(map)
+            }
+        }
+    })
+}
+
 #[pymodule]
 #[pyo3(name = "nitor_vault_rs")]
 fn nitor_vault_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(delete, m)?)?;
     m.add_function(wrap_pyfunction!(delete_many, m)?)?;
     m.add_function(wrap_pyfunction!(exists, m)?)?;
+    m.add_function(wrap_pyfunction!(init, m)?)?;
     m.add_function(wrap_pyfunction!(list_all, m)?)?;
     m.add_function(wrap_pyfunction!(lookup, m)?)?;
     m.add_function(wrap_pyfunction!(run, m)?)?;
     m.add_function(wrap_pyfunction!(store, m)?)?;
+    m.add_function(wrap_pyfunction!(update, m)?)?;
     Ok(())
 }

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -196,6 +196,27 @@ fn run(args: Vec<String>) -> PyResult<()> {
     })
 }
 
+#[pyfunction(signature = (vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
+fn stack_status(
+    vault_stack: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    key: Option<String>,
+    prefix: Option<String>,
+    profile: Option<String>,
+) -> PyResult<HashMap<String, String>> {
+    Runtime::new()?.block_on(async {
+        let data = Vault::new(vault_stack, region, bucket, key, prefix, profile)
+            .await
+            .map_err(vault_error_to_anyhow)?
+            .stack_status()
+            .await
+            .map_err(vault_error_to_anyhow)?;
+
+        Ok(to_hash_map(data, "success".to_string()))
+    })
+}
+
 #[pyfunction(signature = (name, value, vault_stack=None, region=None, bucket=None, key=None, prefix=None, profile=None))]
 fn store(
     name: &str,
@@ -264,6 +285,7 @@ fn nitor_vault_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(list_all, m)?)?;
     m.add_function(wrap_pyfunction!(lookup, m)?)?;
     m.add_function(wrap_pyfunction!(run, m)?)?;
+    m.add_function(wrap_pyfunction!(stack_status, m)?)?;
     m.add_function(wrap_pyfunction!(store, m)?)?;
     m.add_function(wrap_pyfunction!(update, m)?)?;
     Ok(())

--- a/python-pyo3/uv.lock
+++ b/python-pyo3/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "nitor-vault"
-version = "1.0.0"
+version = "2.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/python/n_vault/__init__.py
+++ b/python/n_vault/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Vault module for securely storing secrets in s3 with local encryption with data keys from AWS KMS
+Vault module for securely storing secrets in s3 with local encryption with data keys from AWS KMS.
 """
 
 import sys

--- a/python/n_vault/vault.py
+++ b/python/n_vault/vault.py
@@ -113,6 +113,9 @@ class Vault:
             self._vault_bucket = self._stack + "-" + self._region + "-" + account_id
 
     def store(self, name, data):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+
         encrypted = self._encrypt(data)
         s3(**self._c_args).put_object(
             Bucket=self._vault_bucket,

--- a/python/n_vault/vault.py
+++ b/python/n_vault/vault.py
@@ -207,6 +207,7 @@ class Vault:
         ret = ""
         for item in self.list_all():
             ret = ret + item + os.linesep
+
         return ret
 
     def list_all(self):
@@ -216,6 +217,7 @@ class Vault:
                 ret.append(next_object.key[:-17])
             elif next_object.key.endswith(".encrypted") and next_object.key[:-10] not in ret:
                 ret.append(next_object.key[:-10])
+
         return ret
 
     def get_key(self):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
     { name = "Pasi Niemi", email = "pasi@nitor.com" },
     { name = "Akseli Lukkarila", email = "akseli.lukkarila@nitor.com" },
 ]
-license = { text = "Apache 2.0" }
+license = { text = "Apache-2.0" }
 dependencies = [
     "argcomplete",
     "cryptography",

--- a/rust/src/args.rs
+++ b/rust/src/args.rs
@@ -262,8 +262,17 @@ enum Command {
     },
 }
 
-/// Run Vault CLI with the given arguments
-pub async fn run_cli_with_args(args: Vec<String>) -> Result<()> {
+/// Run Vault CLI with the given arguments.
+///
+/// The argument list needs to include the binary name as the first element.
+pub async fn run_cli_with_args(mut args: Vec<String>) -> Result<()> {
+    // If args are empty, need to manually trigger the help output.
+    // `parse_from` does not do it automatically unlike `parse`.
+    if args.is_empty() {
+        args = vec!["vault".to_string(), "-h".to_string()];
+    } else if args.len() == 1 {
+        args.push("-h".to_string());
+    }
     let args = Args::parse_from(args);
     let quiet = args.quiet;
 
@@ -279,7 +288,7 @@ pub async fn run_cli_with_args(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-/// Run Vault CLI
+/// Run Vault CLI.
 pub async fn run_cli() -> Result<()> {
     let args = Args::parse();
     let quiet = args.quiet;

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -54,8 +54,8 @@ pub enum VaultError {
     S3GetObjectError(#[from] SdkError<GetObjectError>),
     #[error("Failed deleting object from S3")]
     S3DeleteObjectError(#[from] SdkError<DeleteObjectError>),
-    #[error("Key does not exist in S3")]
-    S3DeleteObjectKeyMissingError,
+    #[error("Key does not exist in S3: '{name}'")]
+    S3DeleteObjectKeyMissingError { name: String },
     #[error("Failed getting head-object from S3")]
     S3HeadObjectError(#[from] HeadObjectError),
     #[error("Failed to decrypt S3-object body")]

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -160,13 +160,11 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Utf8(text) => write!(f, "{text}"),
-            Self::Binary(data) => {
-                for byte in data {
-                    write!(f, "{byte:02x}")?;
-                }
-                Ok(())
+            Self::Binary(bytes) => {
+                write!(f, "{}", base64::engine::general_purpose::STANDARD.encode(bytes))?;
             }
         }
+        Ok(())
     }
 }
 

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -161,10 +161,13 @@ impl fmt::Display for Value {
         match self {
             Self::Utf8(text) => write!(f, "{text}"),
             Self::Binary(bytes) => {
-                write!(f, "{}", base64::engine::general_purpose::STANDARD.encode(bytes))?;
+                write!(
+                    f,
+                    "{}",
+                    base64::engine::general_purpose::STANDARD.encode(bytes)
+                )
             }
         }
-        Ok(())
     }
 }
 

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -228,6 +228,8 @@ impl Vault {
     }
 
     /// Get all available secrets.
+    ///
+    /// Returns a list of key names.
     pub async fn all(&self) -> Result<Vec<String>, VaultError> {
         let output = self
             .s3
@@ -258,7 +260,9 @@ impl Vault {
         self.cloudformation_params.clone()
     }
 
-    /// Check if key already exists in bucket.
+    /// Check if the given key name already exists in the S3 bucket.
+    ///
+    /// Returns `true` if the key exists, `false` otherwise.
     pub async fn exists(&self, name: &str) -> Result<bool, VaultError> {
         let name = self.full_key_name(name);
         match self
@@ -283,7 +287,7 @@ impl Vault {
         }
     }
 
-    /// Store encrypted data in S3.
+    /// Store encrypted data with given key name in S3
     pub async fn store(&self, name: &str, data: &[u8]) -> Result<(), VaultError> {
         let encrypted = self.encrypt(data).await?;
 

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -303,7 +303,9 @@ impl Vault {
     /// Delete data in S3 for given key.
     pub async fn delete(&self, name: &str) -> Result<(), VaultError> {
         if !self.exists(name).await? {
-            return Err(VaultError::S3DeleteObjectKeyMissingError);
+            return Err(VaultError::S3DeleteObjectKeyMissingError {
+                name: name.to_string(),
+            });
         }
 
         let key = &self.full_key_name(name);
@@ -315,6 +317,14 @@ impl Vault {
             .send()
             .await?;
 
+        Ok(())
+    }
+
+    /// Delete data for multiple keys.
+    pub async fn delete_many(&self, names: &[String]) -> Result<(), VaultError> {
+        for name in names {
+            self.delete(name).await?;
+        }
         Ok(())
     }
 

--- a/rust/src/vault.rs
+++ b/rust/src/vault.rs
@@ -222,7 +222,7 @@ impl Vault {
         }
     }
 
-    /// Get Cloudformation stack status.
+    /// Get Cloudformation vault stack status.
     pub async fn stack_status(&self) -> Result<CloudFormationStackData, VaultError> {
         cloudformation::get_stack_data(&self.cf, &self.cloudformation_params.stack_name).await
     }
@@ -304,7 +304,7 @@ impl Vault {
         Ok(())
     }
 
-    /// Delete data in S3 for given key.
+    /// Delete data in S3 for given key name.
     pub async fn delete(&self, name: &str) -> Result<(), VaultError> {
         if !self.exists(name).await? {
             return Err(VaultError::S3DeleteObjectKeyMissingError {


### PR DESCRIPTION
Enable using python-pyo3 vault version as a python library. Adds wrappers for accessing most vault functions: 
`all`, `delete`, `delete_many`, `direct_encrypt`, `direct_decrypt`, `exists`, `list_all`, `lookup`, `store`, `init`, `update`, and `stack_status`
(Some of these are new compared to the old python version)

- Re-organize pyo3 package to match old python version: 
  - rename `p_vault` to `n_vault`
  - put Python CLI under `cli.py` and library in `vault.py`
- Add integration tests for Python library usage
- Update python readme with vault library usage instructions 


The `Vault` class in the new library is a dummy class that is only there to make the interface the same as before, so you can use it like before but it does not actually construct a vault instance:

```python
from n_vault import Vault

Vault().store("key", "value")

vault = Vault()
value = vault.lookup("key")
```

Parameters and names are mostly the same, the vault class has some differences due to the Rust vault doing things a bit differently:

```python
# OLD
def __init__(
    self,
    vault_stack="",
    vault_key="",
    vault_bucket="",
    vault_iam_id="",
    vault_iam_secret="",
    vault_prefix="",
    vault_region=None,
    vault_init=False,
):
    
# NEW
def __init__(
    self,
    vault_stack: str = None,
    vault_key: str = None,
    vault_bucket: str = None,
    vault_prefix: str = None,
    vault_region: str = None,
    profile: str = None,
):
```

init, update, and stack_status return dataclasses so data is nicely typed and accessible:
```console
➜  python-pyo3 git:(pyo3-library) ✗ nep nitor-core

➜  python-pyo3 git:(pyo3-library) ✗ python
Python 3.13.0 (main, Oct  7 2024, 05:02:14) [Clang 16.0.0 (clang-1600.0.26.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from n_vault import Vault
>>> Vault().init()
CloudFormationStackData(result='EXISTS', bucket='nitor-core-vault', key='arn:aws:kms:eu-west-1:293246570391:key/726c1aeb-ba7d-4616-ac9f-d67e72774d88', status='UPDATE_COMPLETE', status_reason=None, version=27)
>>> result = Vault().update()
>>> print(result)
CloudFormationStackData(result='UP_TO_DATE', bucket='nitor-core-vault', key='arn:aws:kms:eu-west-1:293246570391:key/726c1aeb-ba7d-4616-ac9f-d67e72774d88', status='UPDATE_COMPLETE', status_reason=None, version=27)
>>> result.bucket
'nitor-core-vault'
>>> Vault(vault_stack="testing-new-library").init()
StackCreated(result='CREATED', stack_name='testing-new-library', stack_id='arn:aws:cloudformation:eu-west-1:293246570391:stack/testing-new-library/01102700-a1d0-11ef-84d1-06ed5a90571f', region='eu-west-1')
```