### PR TITLE
python-pyo3: return bytes from lookup to match previous version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Lookup with Python library
         run: |
-          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library'), end='', flush=True)") <(echo -n sha-${{github.sha}})
+          diff <(python -c "from n_vault import Vault; print(Vault().lookup('secret-python-library').decode('utf-8'), end='', flush=True)") <(echo -n sha-${{github.sha}})
 
       - name: List with Python library
         run: python -c "from n_vault import Vault; print('\n'.join(Vault().list_all()))" | wc -l | grep -q "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault-pyo3"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "nitor-vault",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "2.3.0"
+version = "2.4.0"
 
 [profile.release]
 lto = "thin"

--- a/python-pyo3/python/n_vault/vault.py
+++ b/python-pyo3/python/n_vault/vault.py
@@ -163,11 +163,11 @@ class Vault:
         """
         return nitor_vault_rs.list_all(self.config)
 
-    def lookup(self, name: str) -> str:
+    def lookup(self, name: str) -> bytes:
         """
         Lookup value for given key name.
 
-        Always returns a string, with binary data encoded in base64.
+        Returns raw bytes. Use `.decode("utf-8")` to convert to a string.
         """
         return nitor_vault_rs.lookup(name, self.config)
 

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -197,7 +197,7 @@ fn list_all(config: VaultConfig) -> PyResult<Vec<String>> {
 }
 
 #[pyfunction()]
-fn lookup(name: &str, config: VaultConfig) -> PyResult<Cow<[u8]> {
+fn lookup(name: &str, config: VaultConfig) -> PyResult<Cow<[u8]>> {
     Runtime::new()?.block_on(async {
         let result: Value = Box::pin(
             Vault::from_config(config.into())

--- a/python-pyo3/src/lib.rs
+++ b/python-pyo3/src/lib.rs
@@ -197,7 +197,7 @@ fn list_all(config: VaultConfig) -> PyResult<Vec<String>> {
 }
 
 #[pyfunction()]
-fn lookup(name: &str, config: VaultConfig) -> PyResult<String> {
+fn lookup(name: &str, config: VaultConfig) -> PyResult<Cow<[u8]> {
     Runtime::new()?.block_on(async {
         let result: Value = Box::pin(
             Vault::from_config(config.into())
@@ -208,8 +208,7 @@ fn lookup(name: &str, config: VaultConfig) -> PyResult<String> {
         .await
         .map_err(vault_error_to_anyhow)?;
 
-        // Binary data will get base64 encoded in the Display trait implementation
-        Ok(result.to_string())
+        Ok(Cow::Owned(result.to_bytes()))
     })
 }
 

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -41,12 +41,12 @@ impl Value {
         )
     }
 
+    #[must_use]
     /// Create a `Value` from a string,
     /// and try to decode the value as base64 binary data.
     ///
     /// If the decoded result is valid UTF-8, return `Value::Utf8`.
     /// Otherwise, return `Value::Binary`.
-    #[must_use]
     pub fn from_possibly_base64_encoded(value: String) -> Self {
         #[allow(clippy::option_if_let_else)]
         // ^using `map_or` would require cloning buffer
@@ -96,12 +96,21 @@ impl Value {
         }
     }
 
-    /// Returns the data as a byte slice `&[u8]`
     #[must_use]
+    /// Returns the data as a byte slice `&[u8]`.
     pub fn as_bytes(&self) -> &[u8] {
         match self {
             Self::Utf8(ref string) => string.as_bytes(),
             Self::Binary(ref bytes) => bytes,
+        }
+    }
+
+    #[must_use]
+    /// Returns the data as owned bytes, consuming the Value.
+    pub fn to_bytes(self) -> Vec<u8> {
+        match self {
+            Self::Utf8(string) => string.as_bytes().into(),
+            Self::Binary(bytes) => bytes,
         }
     }
 


### PR DESCRIPTION
Change python library `lookup` to return bytes to match existing behaviour

New behaviour breaks existing code such as:

```shell
    HOOK_URL, SLACK_CHANNEL, SLACK_CHANNEL_ID = vault.lookup(f"dev_carebot_secrets").decode("utf-8").split("!!!")
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```