### PR TITLE
Rust: show separate error message for deprecated encryption type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault-pyo3"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "nitor-vault",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "2.4.0"
+version = "2.5.0"
 
 [profile.release]
 lto = "thin"

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -94,4 +94,8 @@ pub enum VaultError {
     MissingStackIdError,
     #[error("Failed to get stack status for vault stack")]
     MissingStackStatusError,
+    #[error("Deprecated encryption method for secret: {0}")]
+    DeprecatedEncryptionError(String),
+    #[error("Key does not exist in S3")]
+    KeyDoesNotExistError,
 }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -94,8 +94,8 @@ pub enum VaultError {
     MissingStackIdError,
     #[error("Failed to get stack status for vault stack")]
     MissingStackStatusError,
-    #[error("Deprecated encryption method for secret: {0}")]
-    DeprecatedEncryptionError(String),
+    #[error("Deprecated encryption method for secret. Secret needs to be re-encrypted!")]
+    DeprecatedEncryptionError,
     #[error("Key does not exist in S3")]
     KeyDoesNotExistError,
 }


### PR DESCRIPTION
Pasi noticed that we have some vault secrets that still use the old deprecated encryption type. These do not work in the new vault version.

Add a descriptive error for this case:

```console
➜  rust git:(rust-old-encryption) ./vault l amibakery.nitor.zone-ssh-hostkeys.sh
Error: Failed to look up key 'amibakery.nitor.zone-ssh-hostkeys.sh'

Caused by:
    Deprecated encryption method for secret. Secret needs to be re-encrypted!
```

Also adds a separate error for S3 get when the key does not exists vs any other error:

```console
➜  rust git:(rust-old-encryption) ./vault l does-not-exist
Error: Failed to look up key 'does-not-exist'

Caused by:
    Key does not exist in S3
```