### PR TITLE
rust: vault stack list and delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "autocfg"
@@ -132,7 +132,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+checksum = "b5ac934720fbb46206292d2c75b57e67acfc56fe7dfd34fb9a02334af08409ea"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -189,15 +189,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudformation"
-version = "1.55.0"
+version = "1.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224a6166747c95e260bd25bb19cd68c231c482cd61c69f47801d2d9d601ed352"
+checksum = "302e4c85eb7c2ecd2934a01017ae219e59c075de5290bf956c1e0cce77e4d427"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -213,15 +213,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd059dacda4dfd5b57f2bd453fc6555f9acb496cb77508d517da24cf5d73167"
+checksum = "3c30f6fd5646b99d9b45ec3a0c22e67112c175b2383100c960d7ee39d96c8d96"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.63.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43850204a109a5eea1ea93951cf0440268cef98b0d27dfef4534949e23735f7"
+checksum = "d3ba2c5c0f2618937ce3d4a5ad574b86775576fa24006bcb3128c6e2cbf3c34e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -246,7 +246,7 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -269,15 +269,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+checksum = "05ca43a4ef210894f93096039ef1d6fa4ad3edfabb3be92b80908b9f2e4b4eab"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -291,15 +291,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+checksum = "abaf490c2e48eed0bb8e2da2fb08405647bd7f253996e0f93b981958ea0f73b0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -313,15 +313,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
+checksum = "b68fde0d69c8bfdc1060ea7da21df3e39f6014da316783336deff0a9ec28f4bf"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -351,7 +351,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "once_cell",
  "p256",
  "percent-encoding",
@@ -437,6 +437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+checksum = "9f20685047ca9d6f17b994a07f629c813f08b5bce65523e47124879e60103d45"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -483,7 +492,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -501,7 +510,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -627,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -652,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -662,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -695,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -914,9 +923,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1073,12 +1082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1133,7 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1144,7 +1147,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1342,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1466,11 +1469,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1495,7 +1497,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror 2.0.3",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -2103,9 +2105,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2140,11 +2142,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -2160,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2171,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2191,9 +2193,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2211,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2250,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,9 +1385,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libredox"
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "nitor-vault-pyo3"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "nitor-vault",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "2.5.0"
+version = "2.6.0"
 
 [profile.release]
 lto = "thin"

--- a/rust/src/args.rs
+++ b/rust/src/args.rs
@@ -213,9 +213,9 @@ enum Command {
         name: Option<String>,
     },
 
-    /// List all vault stacks
-    #[command(long_flag("list-stacks"))]
-    ListStacks {},
+    /// List all vault Stacks
+    #[command(long_flag("stacks"))]
+    Stacks {},
 
     /// Output secret value for given key
     ///
@@ -388,7 +388,7 @@ async fn run(args: Args) -> Result<()> {
             Command::DeleteStack { name, force } => {
                 println!("{name:?} {force:?}");
             }
-            Command::ListStacks {} => {
+            Command::Stacks {} => {
                 cli::list_stacks(args.region, args.aws_profile, args.quiet).await?;
             }
             // All other commands can use the same single Vault

--- a/rust/src/args.rs
+++ b/rust/src/args.rs
@@ -213,27 +213,6 @@ enum Command {
         name: Option<String>,
     },
 
-    /// Update the vault CloudFormation stack.
-    ///
-    /// The CloudFormation stack declares all resources needed by the vault.
-    ///
-    /// Usage examples:
-    /// - `vault update`
-    /// - `vault update "vault-name"`
-    /// - `vault -u "vault-name"`
-    /// - `vault --vault-stack "vault-name" --update`
-    /// - `VAULT_STACK="vault-name" vault u`
-    #[command(
-        short_flag('u'),
-        long_flag("update"),
-        visible_alias("u"),
-        verbatim_doc_comment
-    )]
-    Update {
-        /// Optional vault stack name
-        name: Option<String>,
-    },
-
     /// List all vault stacks
     #[command(long_flag("list-stacks"))]
     ListStacks {},
@@ -299,17 +278,20 @@ enum Command {
     },
 
     /// Update the vault CloudFormation stack.
+    ///
+    /// The CloudFormation stack declares all resources needed by the vault.
+    ///
+    /// Usage examples:
+    /// - `vault update`
+    /// - `vault update "vault-name"`
+    /// - `vault -u "vault-name"`
+    /// - `vault --vault-stack "vault-name" --update`
+    /// - `VAULT_STACK="vault-name" vault u`
     #[command(
         short_flag('u'),
         long_flag("update"),
         visible_alias("u"),
-        long_about = "Update the CloudFormation stack which declares all resources needed by the vault.\n\n\
-                      Usage examples:\n\
-                      - `vault update`\n\
-                      - `vault update \"vault-name\"`\n\
-                      - `vault -u \"vault-name\"`\n\
-                      - `vault --vault-stack \"vault-name\" --update`\n\
-                      - `VAULT_STACK=\"vault-name\" vault u`"
+        verbatim_doc_comment
     )]
     Update {
         /// Optional vault stack name

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -157,13 +157,7 @@ pub async fn delete_stack(
 
     let config = crate::get_aws_config(region, profile).await;
     let client = aws_sdk_cloudformation::Client::new(&config);
-
-    let stacks = cloudformation::list_stacks(&client).await?;
-
-    let stack = stacks
-        .iter()
-        .find(|stack| stack.stack_name.as_ref() == Some(&stack_name))
-        .context(format!("Vault stack with name '{stack_name}' not found"))?;
+    let stack = cloudformation::get_stack_data(&client, &stack_name).await?;
 
     if !quiet && !force {
         println!("{stack}");

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -157,9 +157,9 @@ pub async fn delete_stack(
 
     let config = crate::get_aws_config(region, profile).await;
     let client = aws_sdk_cloudformation::Client::new(&config);
-    let stack = cloudformation::get_stack_data(&client, &stack_name).await?;
 
     if !quiet && !force {
+        let stack = cloudformation::get_stack_data(&client, &stack_name).await?;
         println!("{stack}");
 
         print!("Are you sure you want to delete this stack? [y/N]: ");

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -192,15 +192,26 @@ pub async fn list_stacks(
         }
     } else {
         if !quiet && stacks.len() > 1 {
-            println!("{}", format!("Found {} stacks:", stacks.len()).bold());
+            println!("{}", format!("Found {} vault stacks:", stacks.len()).bold());
         }
+        let max_chars = stacks
+            .iter()
+            .map(|stack| {
+                stack
+                    .stack_id
+                    .as_ref()
+                    .map_or(0, |id| id.chars().count() + 4)
+            })
+            .max()
+            .unwrap_or(0)
+            .min(120);
         println!(
             "{}",
             stacks
                 .into_iter()
                 .map(|stack| stack.to_string())
                 .collect::<Vec<String>>()
-                .join("\n--------------------------------------------\n")
+                .join(format!("\n{}\n", "-".repeat(max_chars)).as_ref())
         );
     }
 

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -4,6 +4,7 @@ use std::string::FromUtf8Error;
 use aws_sdk_cloudformation::error::SdkError;
 use aws_sdk_cloudformation::operation::create_stack::CreateStackError;
 use aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError;
+use aws_sdk_cloudformation::operation::list_stacks::ListStacksError;
 use aws_sdk_cloudformation::operation::update_stack::UpdateStackError;
 use aws_sdk_cloudformation::Error as cloudformationError;
 use aws_sdk_kms::operation::decrypt::DecryptError;
@@ -98,4 +99,6 @@ pub enum VaultError {
     DeprecatedEncryptionError,
     #[error("Key does not exist in S3")]
     KeyDoesNotExistError,
+    #[error("Failed to list stacks: {0}")]
+    ListVaultStacksError(#[from] SdkError<ListStacksError>),
 }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -3,6 +3,7 @@ use std::string::FromUtf8Error;
 
 use aws_sdk_cloudformation::error::SdkError;
 use aws_sdk_cloudformation::operation::create_stack::CreateStackError;
+use aws_sdk_cloudformation::operation::delete_stack::DeleteStackError;
 use aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError;
 use aws_sdk_cloudformation::operation::list_stacks::ListStacksError;
 use aws_sdk_cloudformation::operation::update_stack::UpdateStackError;
@@ -101,4 +102,6 @@ pub enum VaultError {
     KeyDoesNotExistError,
     #[error("Failed to list stacks: {0}")]
     ListVaultStacksError(#[from] SdkError<ListStacksError>),
+    #[error("Failed to delete stack: {0}")]
+    DeleteVaultStackError(#[from] SdkError<DeleteStackError>),
 }


### PR DESCRIPTION
When I was implementing the init and update commands for the rust vault, I needed to create multiple vault stacks for testing. Deleting all of these by having to go to the aws console was annoying and recently noticed I had forgotten to delete one of them, so adding CLI commands to list all vault stacks and delete a vault stack.

Repurposes the `status` command as `stack` and adds the stack list and delete as subcommands for that.

In action:
```console
➜  rust git:(list-destroy-stacks) ./vault -h
Encrypted AWS key-value storage utility

Usage: vault [OPTIONS] [COMMAND]

Commands:
  all, -a, --all            List available secrets [aliases: a, list, ls]
  completion, --completion  Generate shell completions
  delete, -d, --delete      Delete an existing key from the store [aliases: d]
  describe, --describe      Print CloudFormation stack parameters for current configuration
  decrypt, -y, --decrypt    Directly decrypt given value [aliases: y]
  encrypt, -e, --encrypt    Directly encrypt given value [aliases: e]
  exists, --exists          Check if a key exists
  info, --info              Print vault information
  id                        Print AWS user account information
  stack                     Commands for cloudformation stack
  init, -i, --init          Initialize a new KMS key and S3 bucket. [aliases: i]
  lookup, -l, --lookup      Output secret value for given key [aliases: l]
  store, -s, --store        Store a new key-value pair. [aliases: s]
  update, -u, --update      Update the vault CloudFormation stack. [aliases: u]
  help                      Print this message or the help of the given subcommand(s)

Options:
  -b, --bucket <BUCKET>    Override the bucket name [env: VAULT_BUCKET=]
  -k, --key-arn <ARN>      Override the KMS key ARN [env: VAULT_KEY=]
  -p, --prefix <PREFIX>    Optional prefix for key name [env: VAULT_PREFIX=]
  -r, --region <REGION>    Specify AWS region for the bucket [env: AWS_REGION=]
      --vaultstack <NAME>  Specify CloudFormation stack name to use [env: VAULT_STACK=]
      --id <ID>            Specify AWS IAM access key ID
      --secret <SECRET>    Specify AWS IAM secret access key
      --profile <PROFILE>  Specify AWS profile name to use [env: AWS_PROFILE=nitor-core]
  -q, --quiet              Suppress additional output and error messages
  -h, --help               Print help (see more with '--help')
  -V, --version            Print version

➜  rust git:(list-destroy-stacks) ./vault help stack
Commands for cloudformation stack.

No subcommand prints vault stack information.

Usage: vault stack [COMMAND]

Commands:
  list, -l, --list  List all vault stacks [aliases: l, ls]
  delete, --delete  Delete vault stack
  help              Print this message or the help of the given subcommand(s)

Options:
  -h, --help
          Print help (see a summary with '-h')

➜  rust git:(list-destroy-stacks) ./vault stack
status: UPDATE_COMPLETE
bucket: nitor-core-vault
key: arn:aws:kms:eu-west-1:293246570391:key/726c1aeb-ba7d-4616-ac9f-d67e72774d88
version: 27

➜  rust git:(list-destroy-stacks) ./vault stack ls
Found 2 vault stacks:
name: pythontest
id: arn:aws:cloudformation:eu-west-1:293246570391:stack/pythontest/d3368ad0-92f3-11ef-b93b-0a42694f9dd5
description: Nitor Vault stack
status: CreateComplete
-------------------------------------------------------------------------------------------------------
name: vault
id: arn:aws:cloudformation:eu-west-1:293246570391:stack/vault/bdbbd470-b693-11e6-b4f9-50faf00dccfd
description: Nitor Vault stack
status: UpdateComplete

➜  rust git:(list-destroy-stacks) ./vault stack delete pythontest
name: pythontest
id: arn:aws:cloudformation:eu-west-1:293246570391:stack/pythontest/d3368ad0-92f3-11ef-b93b-0a42694f9dd5
description: Nitor Vault stack
status: CreateComplete
Are you sure you want to delete this stack? [y/N]: y
Stack deletion initiated
``` 