### PR TITLE
python-pyo3: use static async runtime

### DIFF
--- a/python-pyo3/Cargo.toml
+++ b/python-pyo3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nitor-vault-pyo3"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.80"
 
 [lib]
 name = "nitor_vault_rs"


### PR DESCRIPTION
Hi @Esgrove, I was at the python meetup and after that I checked this repository.

The patch makes python-pyo3 use one static async runtime for the lifetime of the module, so it will improve performance at the price of negligible increase in memory usage.

The patch uses the Rust feature LazyLock which was introduced with 1.80, that's why the minimum rust version was set.

I haven't found any CI pipeline configuration so I'm not sure if this is acceptable. If you don't want to limit yourself to the rust version 1.80 I can implement the changes with the crate [lazy_static](https://crates.io/crates/lazy_static).